### PR TITLE
Upgrade to Ruby 2.1.6 and update Bundler to latest.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && \
         systemtap && \
     apt-get clean
 RUN mkdir -p /usr/src && \
-    curl http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2 | \
+    curl http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2 | \
         tar -C /usr/src -xj
-RUN cd /usr/src/ruby-2.1.5 && \
+RUN cd /usr/src/ruby-2.1.6 && \
     autoconf && \
     ./configure --prefix=/usr --disable-install-doc && \
     make && make install && make clean
-RUN gem install -q --no-rdoc --no-ri bundler --version 1.7.6
+RUN gem install -q --no-rdoc --no-ri bundler --version 1.10.4


### PR DESCRIPTION
Upgrade required, since Ruby 2.1.5 had a serious security flaw: https://www.ruby-lang.org/en/news/2015/04/13/ruby-2-1-6-released/