### PR TITLE
Provide basic tests for the appengine base image

### DIFF
--- a/appengine/Rakefile
+++ b/appengine/Rakefile
@@ -1,0 +1,13 @@
+require "rake/testtask"
+
+::Dir.chdir(::File.dirname(__FILE__))
+
+task :default => [:build, :test]
+
+task :build do
+  sh("docker build -t appengine-ruby-base .")
+end
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/tc_*.rb']
+end

--- a/appengine/test/minimal_app/Dockerfile
+++ b/appengine/test/minimal_app/Dockerfile
@@ -1,0 +1,5 @@
+FROM appengine-ruby-base
+COPY Gemfile Gemfile.lock /app/
+RUN bundle install && rbenv rehash
+COPY . /app/
+ENTRYPOINT bundle exec rackup -p 8080 -E production config.ru

--- a/appengine/test/minimal_app/Gemfile
+++ b/appengine/test/minimal_app/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'rack', '>= 1.6.4'

--- a/appengine/test/minimal_app/Gemfile.lock
+++ b/appengine/test/minimal_app/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (1.6.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack (>= 1.6.4)
+
+BUNDLED WITH
+   1.10.6

--- a/appengine/test/minimal_app/config.ru
+++ b/appengine/test/minimal_app/config.ru
@@ -1,0 +1,1 @@
+run Proc.new { |env| [200, {'Content-Type' => 'text/plain'}, ["ruby app"]] }

--- a/appengine/test/tc_base_image.rb
+++ b/appengine/test/tc_base_image.rb
@@ -1,0 +1,18 @@
+require "minitest/autorun"
+require_relative "test_helper.rb"
+
+
+# Basic tests on the content of the base image
+
+class TestBaseImage < ::Minitest::Test
+
+  include TestHelper
+
+
+  def test_ruby_installation
+    assert_cmd_output(
+      "docker run --entrypoint=ruby appengine-ruby-base --version",
+      /^ruby 2\.3\.0/)
+  end
+
+end

--- a/appengine/test/tc_base_image.rb
+++ b/appengine/test/tc_base_image.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require_relative "test_helper.rb"
+require_relative "test_helper"
 
 
 # Basic tests on the content of the base image

--- a/appengine/test/tc_sample_apps.rb
+++ b/appengine/test/tc_sample_apps.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require_relative "test_helper.rb"
+require_relative "test_helper"
 
 
 # Tests of a bunch of sample apps. Treats every subdirectory of the test

--- a/appengine/test/tc_sample_apps.rb
+++ b/appengine/test/tc_sample_apps.rb
@@ -28,9 +28,8 @@ class TestSampleApps < ::Minitest::Test
   def run_app_test(dirname)
     puts("**** Testing app: #{dirname}")
     ::Dir.chdir(::File.join(::File.dirname(__FILE__), dirname)) do |dir|
-      num = rand(1000000)
-      container = "ruby-app-#{num}"
-      image = "appengine-ruby-test-#{num}"
+      container = "ruby-app-#{dirname}"
+      image = "appengine-ruby-test-#{dirname}"
       begin
         assert_cmd_succeeds "docker build -t #{image} ."
         begin

--- a/appengine/test/tc_sample_apps.rb
+++ b/appengine/test/tc_sample_apps.rb
@@ -1,0 +1,49 @@
+require "minitest/autorun"
+require_relative "test_helper.rb"
+
+
+# Tests of a bunch of sample apps. Treats every subdirectory of the test
+# directory that contains a Dockerfile as a sample app. Builds the docker
+# image, runs the server, and hits the root of the server, expecting the
+# string "ruby app" to be returned.
+#
+# This is supposed to exercise the base image extended in various ways, so
+# the sample app Dockerfiles should all inherit FROM the base image, which
+# will be called "appengine-ruby-base".
+
+class TestSampleApps < ::Minitest::Test
+
+  include TestHelper
+
+
+  ::Dir.glob("#{::File.dirname(__FILE__)}/*/Dockerfile").each do |dockerfile|
+    test_dir = ::File.dirname(dockerfile)
+    base_name = ::File.basename(test_dir)
+    define_method("test_#{base_name}") do
+      run_app_test(base_name)
+    end
+  end
+
+
+  def run_app_test(dirname)
+    puts("**** Testing app: #{dirname}")
+    ::Dir.chdir(::File.join(::File.dirname(__FILE__), dirname)) do |dir|
+      num = rand(1000000)
+      container = "ruby-app-#{num}"
+      image = "appengine-ruby-test-#{num}"
+      begin
+        assert_cmd_succeeds "docker build -t #{image} ."
+        begin
+          assert_cmd_succeeds "docker run -d -p 8080:8080 --name #{container} #{image}"
+          assert_cmd_output("curl -s -S http://127.0.0.1:8080/", "ruby app", 5)
+        ensure
+          execute_cmd "docker kill #{container}"
+          execute_cmd "docker rm #{container}"
+        end
+      ensure
+        execute_cmd "docker rmi #{image}"
+      end
+    end
+  end
+
+end

--- a/appengine/test/test_helper.rb
+++ b/appengine/test/test_helper.rb
@@ -22,22 +22,20 @@ module TestHelper
   # Flunks if it does not succeed and produce output matching the given
   # expectation (string or regex) within the given timeout in seconds.
   def assert_cmd_output(cmd, expectation, timeout=0)
-    iter = 0
-    loop do
+    actual = ""
+    exit_code = 0
+    0.upto(timeout) do |iter|
       puts cmd
       actual = `#{cmd}`
       exit_code = $?.exitstatus
       if exit_code == 0 && (expectation == nil || expectation === actual)
         return actual
       end
-      iter += 1
-      if iter >= timeout
-        flunk "Expected \"#{expectation.inspect}\" but got \"#{actual}\"" +
-          " (exit code #{exit_code}) when executing \"#{cmd}\""
-      end
       puts("...expected result did not arrive yet (iteration #{iter})...")
       sleep(1)
     end
+    flunk "Expected #{expectation.inspect} but got \"#{actual}\"" +
+      " (exit code #{exit_code}) when executing \"#{cmd}\""
   end
 
 end

--- a/appengine/test/test_helper.rb
+++ b/appengine/test/test_helper.rb
@@ -1,0 +1,43 @@
+# A set of helpful methods and assertions for running tests.
+
+module TestHelper
+
+  # Execute the given command in a shell.
+  def execute_cmd(cmd)
+    puts cmd
+    system cmd
+  end
+
+  # Assert that execution of the given command produces a zero exit code.
+  def assert_cmd_succeeds(cmd)
+    puts cmd
+    system cmd
+    exit_code = $?.exitstatus
+    if exit_code != 0
+      flunk "Got exit code #{exit_code} when executing \"#{cmd}\""
+    end
+  end
+
+  # Repeatedly execute the given command (with a pause between tries).
+  # Flunks if it does not succeed and produce output matching the given
+  # expectation (string or regex) within the given timeout in seconds.
+  def assert_cmd_output(cmd, expectation, timeout=0)
+    iter = 0
+    loop do
+      puts cmd
+      actual = `#{cmd}`
+      exit_code = $?.exitstatus
+      if exit_code == 0 && (expectation == nil || expectation === actual)
+        return actual
+      end
+      iter += 1
+      if iter >= timeout
+        flunk "Expected \"#{expectation.inspect}\" but got \"#{actual}\"" +
+          " (exit code #{exit_code}) when executing \"#{cmd}\""
+      end
+      puts("...expected result did not arrive yet (iteration #{iter})...")
+      sleep(1)
+    end
+  end
+
+end


### PR DESCRIPTION
Provided two Ruby (minitest) based test files, one that runs checks
directly on the base image, and one that builds and runs a set of apps.
Currently, only one test app is provided: a minimal app using Rack.

Also provide a Rakefile that runs the test suite.