### PR TITLE
Provide a config to activate Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+language: ruby
+
+services:
+  - docker
+
+before_install:
+  - docker pull gcr.io/google_appengine/base
+  - gem install minitest
+
+script:
+  - rake -f appengine/Rakefile

--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -55,9 +55,10 @@ ENV PATH /rbenv/shims:/rbenv/bin:$PATH
 
 # Preinstall ruby runtimes.
 # The LAST version in the list is set as the default.
-ENV PREINSTALLED_RUBY_VERSIONS 2.0.0-p648 2.1.8 2.2.3 2.2.4 2.3.0
+ENV PREINSTALLED_RUBY_VERSIONS 2.1.8 2.2.4 2.3.0
+ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN for V in $PREINSTALLED_RUBY_VERSIONS; do \
-    rbenv install $V; \
+    rbenv install -v $V; \
     rbenv rehash; \
     rbenv global $V; \
     done

--- a/appengine/README.md
+++ b/appengine/README.md
@@ -21,7 +21,7 @@ This image is designed for Ruby Rack applications. It does the following:
   assuming that an appropriate `/app/config.ru` is present.
 
 The following tasks are _not_ handled by this base image, and should be
-performed by your inherited Dockerfile:
+performed by your inheriting Dockerfile:
 
 - Use rbenv to install a custom ruby runtime, if desired.
 - Install any native libraries needed by required gems.


### PR DESCRIPTION
Also, some updates to the Dockerfile to reduce its size and the time
needed to build it (in part, to speed up runs of tests).

See also https://github.com/GoogleCloudPlatform/ruby-docker/pull/24