### PR TITLE
no longer default to webrick

### DIFF
--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -82,6 +82,5 @@ ENV PORT 8080
 CMD []
 
 # Default ENTRYPOINT
-ENV RACK_HANDLER webrick
 ENV RACK_ENV production
-ENTRYPOINT bundle exec rackup -p $PORT config.ru -s $RACK_HANDLER -E $RACK_ENV
+ENTRYPOINT bundle exec rackup -p $PORT config.ru -E $RACK_ENV


### PR DESCRIPTION
 * Rack respects $RACK_HANDLER when no args are supplied
 * Rack will default to thin, then puma, then webrick by default (need to
   recommend doing puma first).