### PR TITLE
Work around for imagemagick security issue

### DIFF
--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -77,6 +77,11 @@ RUN for V in $PREINSTALLED_RUBY_VERSIONS; do \
 RUN bundle config build.nokogiri --use-system-libraries
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES 1
 
+# Temporarily replace ImageMagick policy file with one that fixes
+# CVE-2016-3714
+RUN mkdir -p /etc/ImageMagick-6 && rm -f /etc/ImageMagick-6/policy.xml
+COPY files/policy.xml /etc/ImageMagick-6/
+
 # Common configuration for any ENTRYPOINT
 WORKDIR /app
 EXPOSE 8080

--- a/appengine/files/policy.xml
+++ b/appengine/files/policy.xml
@@ -1,0 +1,13 @@
+<policymap>
+
+  <!-- This is in the default policy.xml -->
+  <policy domain="cache" name="shared-secret" value="passphrase" />
+
+  <!-- Disable certain features to fix CVE-2016-3714 -->
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
+
+</policymap>


### PR DESCRIPTION
Add a policy.xml file disabling certain capabilities to close off CVE-2016–3714