### PR TITLE
Set application environment variables to production by default

### DIFF
--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -87,5 +87,8 @@ ENV PORT 8080
 CMD []
 
 # Default ENTRYPOINT
-ENV RACK_ENV deployment
+ENV RACK_ENV=production \
+    RAILS_ENV=production \
+    APP_ENV=production \
+    RAILS_SERVE_STATIC_FILES=true
 ENTRYPOINT bundle exec rackup -p $PORT config.ru -E $RACK_ENV


### PR DESCRIPTION
Set these to match the current override values in the gcloud-generated Dockerfile so they can be removed from the latter.