### PR TITLE
Provide a Dockerfile for obsolete google/ruby images.

### DIFF
--- a/obsolete/Dockerfile
+++ b/obsolete/Dockerfile
@@ -1,0 +1,24 @@
+FROM gcr.io/google_appengine/base
+
+ENV MESSAGE \\n\
+********************************** NOTICE **********************************\\n\
+\\n\
+  The google/ruby images have been obsoleted.\\n\
+\\n\
+  If you want to deploy a Ruby application to Google App Engine, please use\\n\
+  gcr.io/google_appengine/ruby as your base image.\\n\
+\\n\
+  See http://cloud.google.com/ruby for more information on running Ruby on\\n\
+  Google Cloud Platform.\\n\
+\\n\
+  If you are looking for a generic Ruby base image, consider the official\\n\
+  Ruby image on DockerHub at https://hub.docker.com/_/ruby/\\n\
+\\n\
+********************************** NOTICE **********************************\\n\
+\\n
+
+# Prevent (most) docker runs of this image and print the above message.
+ENTRYPOINT printf "$MESSAGE" && printf "ABORTING CONTAINER\\n\\n" && false
+
+# Prevent inheriting of this image and print the above message.
+ONBUILD RUN printf "$MESSAGE" && printf "ABORTING BUILD\\n\\n" && false

--- a/obsolete/Dockerfile
+++ b/obsolete/Dockerfile
@@ -5,9 +5,10 @@ ENV MESSAGE \\n\
 \\n\
   The google/ruby images have been obsoleted.\\n\
 \\n\
-  If you want to deploy a Ruby application to Google App Engine, please use\\n\
+  If you want to deploy a Ruby application to Google App Engine, you can\\n\
+  simply specify "runtime: ruby" in your app.yaml configuration file.\\n\
+  If you'd like to extend the Ruby for App Engine runtime, you can use\\n\
   gcr.io/google_appengine/ruby as your base image.\\n\
-\\n\
   See http://cloud.google.com/ruby for more information on running Ruby on\\n\
   Google Cloud Platform.\\n\
 \\n\

--- a/obsolete/README.md
+++ b/obsolete/README.md
@@ -1,0 +1,11 @@
+# Obsolete images
+
+The following images are now obsolete:
+
+*   [`google/ruby`](https://hub.docker.com/r/google/ruby/)
+*   [`google/ruby-runtime`](https://hub.docker.com/r/google/ruby-runtime/)
+*   [`google/ruby-hello`](https://hub.docker.com/r/google/ruby-hello/)
+
+If you want to deploy a Ruby application to Google App Engine, please use gcr.io/google_appengine/ruby as your base image. See http://cloud.google.com/ruby for more information on using Ruby on Google Cloud Platform.
+
+If you are looking for a generic Ruby base image, consider the [official Ruby image on DockerHub](https://hub.docker.com/_/ruby/).


### PR DESCRIPTION
This Dockerfile creates a disabled image, displaying an error on image and container creation that points users to the correct base images to use.
Once it is in place, we will switch the auto-build for the obsolete google/ruby, google/ruby-runtime, and google/ruby-hello images to point to this Dockerfile, disabling those images. We may, at some point later, actually delete the images altogether.