### PR TITLE
Configure apt-get to see GCP's pre-built ruby binary packages and preinstall only one ruby using those packages

### DIFF
--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -41,9 +41,7 @@ RUN apt-get update -y && \
         libcurl3-gnutls \
         libcurl4-openssl-dev \
         libmagickwand-dev \
-        systemtap && \
-    apt-get clean && \
-    rm /var/lib/apt/lists/*_*
+        systemtap
 
 # Install node
 RUN mkdir /nodejs && curl https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
@@ -55,22 +53,22 @@ RUN git clone https://github.com/sstephenson/rbenv.git /rbenv && \
     git clone https://github.com/sstephenson/ruby-build.git /rbenv/plugins/ruby-build
 ENV PATH /rbenv/shims:/rbenv/bin:$PATH
 
-# Preinstall ruby runtimes.
-# The LAST version in the list is set as the default.
-ENV PREINSTALLED_RUBY_VERSIONS 2.1.8 2.2.4 2.3.0
-ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-RUN for V in $PREINSTALLED_RUBY_VERSIONS; do \
-    rbenv install -v $V; \
-    rbenv rehash; \
-    rbenv global $V; \
-    done
-
-# Preinstall bundler gem
+# Preinstalled default ruby version.
+ENV RBENV_VERSION 2.3.1
 ENV BUNDLER_VERSION 1.12.5
-RUN for V in $PREINSTALLED_RUBY_VERSIONS; do \
-    RBENV_VERSION=$V gem install -q --no-rdoc --no-ri bundler --version $BUNDLER_VERSION; \
-    rbenv rehash; \
-    done
+
+# Install the default ruby binary and bundler.
+RUN (echo "deb http://packages.cloud.google.com/apt ruby-runtime-jessie main" \
+      | tee /etc/apt/sources.list.d/ruby-runtime-jessie.list) && \
+    (curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | apt-key add -) && \
+    apt-get update -y && \
+    apt-get install -y -q gcp-ruby-$RBENV_VERSION && \
+    rbenv rehash && \
+    rbenv global $RBENV_VERSION && \
+    gem install -q --no-rdoc --no-ri bundler --version $BUNDLER_VERSION && \
+    rbenv rehash
+
 # Tell nokogiri >=1.6 to install using system libraries, for faster builds
 RUN bundle config build.nokogiri --use-system-libraries
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES 1
@@ -79,6 +77,9 @@ ENV NOKOGIRI_USE_SYSTEM_LIBRARIES 1
 # CVE-2016-3714 and others.
 RUN mkdir -p /etc/ImageMagick-6 && rm -f /etc/ImageMagick-6/policy.xml
 COPY files/policy.xml /etc/ImageMagick-6/
+
+# Clean up apt
+RUN apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Common configuration for any ENTRYPOINT
 WORKDIR /app

--- a/appengine/README.md
+++ b/appengine/README.md
@@ -3,19 +3,21 @@
 [`gcr.io/google_appengine/ruby`](http://cloud.google.com/ruby) is a
 [Docker](https://docker.com) base image that bundles stable versions of
 [Ruby](http://ruby-lang.org) and [Bundler](http://bundler.io), and makes it
-easy to containerize standard [Rack](http://rack.github.io) applications.
+easy to containerize standard [Rack](http://rack.github.io) applications. It
+is used primarily as a base image for deploying Ruby applications to the
+[Google App Engine flexible environment](https://cloud.google.com/appengine/docs/flexible/).
 
 ## About this image
 
-This image is designed for Ruby Rack applications. It does the following:
+This image is designed for Ruby web applications. It does the following:
 
 - It installs a recent version of Debian, the system libraries needed by the
   standard Ruby runtime, and a recent version of [NodeJS](http://nodejs.org).
 - It installs [rbenv](https://github.com/sstephenson/rbenv) with the
   [ruby-build](https://github.com/sstephenson/ruby-build) plugin.
-- Using ruby-build, it installs several recent supported versions of the
-  standard Ruby runtime. With each runtime, it installs a recent version of
-  [bundler](http://bundler.io) and [foreman](https://github.com/ddollar/foreman).
+- It installs a recent supported version of the standard
+  [Ruby interpreter](http://ruby-lang.org/) and configures rbenv to use it by
+  default. It also installs a recent version of [bundler](http://bundler.io).
 - It sets the working directory to `/app` and exposes port 8080.
 - It configures a standard `ENTRYPOINT` which runs `rackup` on port 8080,
   assuming that an appropriate `/app/config.ru` is present.
@@ -23,7 +25,7 @@ This image is designed for Ruby Rack applications. It does the following:
 The following tasks are _not_ handled by this base image, and should be
 performed by your inheriting Dockerfile:
 
-- Use rbenv to install a custom ruby runtime, if desired.
+- Use rbenv to install and select a custom ruby runtime, if desired.
 - Install any native libraries needed by required gems.
 - Copy application files into the `/app` directory.
 - Run `bundle install`.
@@ -39,7 +41,8 @@ performed by your inheriting Dockerfile:
     - `Gemfile.lock`
     - `config.ru`
 
-- Create a Dockerfile in your ruby application directory with the following content.
+- Create a Dockerfile in your ruby application directory with the following
+  content.
 
         FROM gcr.io/google_appengine/ruby
         COPY Gemfile Gemfile.lock /app/

--- a/appengine/test/tc_base_image.rb
+++ b/appengine/test/tc_base_image.rb
@@ -12,7 +12,7 @@ class TestBaseImage < ::Minitest::Test
   def test_ruby_installation
     assert_cmd_output(
       "docker run --entrypoint=ruby appengine-ruby-base --version",
-      /^ruby 2\.3\.0/)
+      /^ruby 2\.3\.1/)
   end
 
 end


### PR DESCRIPTION
This should reduce the base image size considerably, but at the cost of eliminating some preinstalled rubies. Therefore, this should not be merged until the gcloud sdk generates Dockerfiles that use the pre-built binary packages to speed up ruby installations (now available in gcloud 126.0.0, released 2016.09.14). Note that we are also changing the default ruby version from 2.3.0 to 2.3.1.