### PR TITLE
Clarify App Engine usage in the README

### DIFF
--- a/obsolete/Dockerfile
+++ b/obsolete/Dockerfile
@@ -7,8 +7,8 @@ ENV MESSAGE \\n\
 \\n\
   If you want to deploy a Ruby application to Google App Engine, you can\\n\
   simply specify "runtime: ruby" in your app.yaml configuration file.\\n\
-  If you'd like to extend the Ruby for App Engine runtime, you can use\\n\
-  gcr.io/google_appengine/ruby as your base image.\\n\
+  If you'd like to extend the Ruby runtime for App Engine, use\\n\
+  "gcr.io/google_appengine/ruby" as the base image.\\n\
   See http://cloud.google.com/ruby for more information on running Ruby on\\n\
   Google Cloud Platform.\\n\
 \\n\

--- a/obsolete/README.md
+++ b/obsolete/README.md
@@ -6,6 +6,10 @@ The following images are now obsolete:
 *   [`google/ruby-runtime`](https://hub.docker.com/r/google/ruby-runtime/)
 *   [`google/ruby-hello`](https://hub.docker.com/r/google/ruby-hello/)
 
-If you want to deploy a Ruby application to Google App Engine, please use gcr.io/google_appengine/ruby as your base image. See http://cloud.google.com/ruby for more information on using Ruby on Google Cloud Platform.
+If you want to deploy a Ruby application to Google App Engine, you can simply specify "runtime: ruby" in your app.yaml configuration file.
+
+If you'd like to extend the Ruby runtime for App Engine, use "gcr.io/google_appengine/ruby" as the base image.
+
+See http://cloud.google.com/ruby for more information on using Ruby on Google Cloud Platform.
 
 If you are looking for a generic Ruby base image, consider the [official Ruby image on DockerHub](https://hub.docker.com/_/ruby/).


### PR DESCRIPTION
This messaging change was previously made in the dockerfile error message, but missed in the README.