### PR TITLE
Stop pre-pulling the wrong docker base image in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - docker
 
 before_install:
-  - docker pull gcr.io/google_appengine/base
   - gem install minitest
 
 script:


### PR DESCRIPTION
This step used to be in the travis config, IIRC, to force pull the latest base image. However, we're doing that now with `docker build --pull`, so it's redundant. It's also now pulling the incorrect base image since we recently changed to debian8.