### PR TITLE
Fix trailing comma in test_base_image.json

### DIFF
--- a/appengine/test/test_base_image.json
+++ b/appengine/test/test_base_image.json
@@ -26,5 +26,5 @@
 			"command": ["ruby", "-e", "puts ENV[\"RAILS_ENV\"]"],
 			"expectedOutput": ["production\n"]
 		}
-	],
+	]
 }


### PR DESCRIPTION
The cloud build tests are failing because of this extra trailing comma in config json file.

Test by running `$ appengine/build.sh gcr.io/google_appengine/ruby:test`, and make sure the script at least completes Step 1 without the JSON parsing error.