### PR TITLE
Add RUNTIME_DISTRIBUTION argument to Dockerfile

### DIFF
--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -57,8 +57,11 @@ ENV PATH /rbenv/shims:/rbenv/bin:$PATH
 ENV DEFAULT_RUBY_VERSION 2.3.1
 ENV BUNDLER_VERSION 1.13.6
 
+# Set ruby runtime distribution
+ARG RUNTIME_DISTRIBUTION="ruby-runtime-jessie"
+
 # Install the default ruby binary and bundler.
-RUN (echo "deb http://packages.cloud.google.com/apt ruby-runtime-jessie main" \
+RUN (echo "deb http://packages.cloud.google.com/apt ${RUNTIME_DISTRIBUTION} main" \
       | tee /etc/apt/sources.list.d/ruby-runtime-jessie.list) && \
     (curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
       | apt-key add -) && \


### PR DESCRIPTION
Add the RUNTIME_DISTRIBUTION argument to Dockerfile, so we have an option to choose which ruby runtime binary distribution repository to use. This also gives us a way to test any staging runtime binaries in GAE Flex workflow.