### PR TITLE
Cause Rails 5 to log to STDOUT in production by default.

### DIFF
--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -91,5 +91,6 @@ CMD []
 ENV RACK_ENV=production \
     RAILS_ENV=production \
     APP_ENV=production \
-    RAILS_SERVE_STATIC_FILES=true
+    RAILS_SERVE_STATIC_FILES=true \
+    RAILS_LOG_TO_STDOUT=true
 ENTRYPOINT bundle exec rackup -p $PORT config.ru -E $RACK_ENV


### PR DESCRIPTION
This will cause logs to appear in the Google Cloud console (albeit without severity information, etc.) even if the logging or appengine gems are not installed.