### PR TITLE
Update Dockerfile to include `file` utility

### DIFF
--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -y && \
         ca-certificates \
         curl \
         git \
+        file \
         libffi-dev \
         libgdbm-dev \
         libgmp-dev \


### PR DESCRIPTION
Apparently `paperclip` needs it to check the filetype.
Footprint is 2 extra packages: `file` and `libmagic1` for some reason so should be reasonable.

I've built the image ok, but please, test :)