### PR TITLE
adding license tests to ruby structure tests

### DIFF
--- a/appengine/test/test_base_image.json
+++ b/appengine/test/test_base_image.json
@@ -26,5 +26,13 @@
 			"command": ["ruby", "-e", "puts ENV[\"RAILS_ENV\"]"],
 			"expectedOutput": ["production\n"]
 		}
+	],
+	"licenseTests": [
+		{
+			"debian": true,
+			"files": [
+				"/nodejs/LICENSE"
+			]
+		}
 	]
 }


### PR DESCRIPTION
License tests are automated tests to check that all packages installed in the image conform to Google's open source licensing stardards. Check out https://github.com/GoogleCloudPlatform/runtimes-common/blob/master/structure_tests/licenses_test.go (and the corresponding README) for more details.