### PR TITLE
Update ruby build steps to support runtime build versions

### DIFF
--- a/builder/.gitignore
+++ b/builder/.gitignore
@@ -1,5 +1,6 @@
 test/tmp
-tmp
+pipeline
 build_steps/gen_dockerfile.yaml
 build_steps/build_app.yaml
-ruby.yaml
+build_steps/gen_dockerfile/Dockerfile
+build_steps/build_app/Dockerfile

--- a/builder/Rakefile
+++ b/builder/Rakefile
@@ -17,72 +17,44 @@ require "erb"
 
 STEPS = ["build_app", "gen_dockerfile"]
 DEFAULT_PROJECT = "cloud-builders"
+DEFAULT_TAG = "latest"
 
 ::Dir.chdir(::File.dirname __FILE__)
 
-def image_for_step step
-  "ruby-#{step.gsub '_', '-'}"
-end
-
 STEPS.each do |step|
-  step_image = image_for_step step
-
-  desc "Build local docker image for #{step_image}"
-  task "build:#{step}:local", :name do |t, args|
-    name = args[:name] || step_image
+  desc "Build local docker image for #{step}"
+  task "build:#{step}:local", :image do |t, args|
+    image = args[:image] || "ruby-#{step.gsub '_', '-'}"
     ::Dir.chdir "build_steps" do
-      sh "docker build --pull --no-cache -t #{name} -f #{step}/Dockerfile ."
+      sh "sed -e 's/$BASE_TAG/latest/g'" \
+        " < #{step}/Dockerfile.in > #{step}/Dockerfile"
+      sh "docker build --pull --no-cache -t #{image} -f #{step}/Dockerfile ."
     end
   end
 
-  desc "Build #{step_image} to a given project"
-  task "build:#{step}:project", :project, :tag do |t, args|
-    project = args[:project]
-    fail "Project name required" unless project
-    tag = args[:tag] || "latest"
-    sh "./build_#{step}.sh gcr.io/#{project}/#{step_image}:#{tag}"
-  end
-
-  desc "Build #{step_image} to a given tag on the canonical image path"
-  task "build:#{step}:tag", :tag do |t, args|
-    tag = args[:tag]
-    fail "Tag name required" unless tag
-    sh "./build_#{step}.sh gcr.io/#{DEFAULT_PROJECT}/#{step_image}:#{tag}"
+  desc "Build #{step} to a given tag and project"
+  task "build:#{step}", :tag, :project do |t, args|
+    tag = args[:tag] || DEFAULT_TAG
+    project = args[:project] || DEFAULT_PROJECT
+    sh "./build_#{step}.sh #{tag} #{project}"
   end
 end
 
 desc "Build local docker image for all steps"
 task "build:local" => STEPS.map { |step| "build:#{step}:local" }
 
-desc "Build all steps to a given project"
-task "build:project", :project, :tag do |t, args|
-  project = args[:project]
-  fail "Project name required" unless project
-  tag = args[:tag] || "latest"
-  STEPS.each do |step|
-    step_image = image_for_step step
-    sh "./build_#{step}.sh gcr.io/#{project}/#{step_image}:#{tag}"
-  end
-end
-
-desc "Build all steps to a given tag on the canonical image path"
-task "build:tag", :tag do |t, args|
-  tag = args[:tag]
-  fail "Tag name required" unless tag
-  STEPS.each do |step|
-    step_image = image_for_step step
-    sh "./build_#{step}.sh gcr.io/#{DEFAULT_PROJECT}/#{step_image}:#{tag}"
-  end
-end
-
 desc "Generate pipeline ruby.yaml"
-task "gen_pipeline", :project, :tag do |t, args|
+task "build:pipeline", :tag, :project do |t, args|
+  tag = args[:tag] || DEFAULT_TAG
   project = args[:project] || DEFAULT_PROJECT
-  tag = args[:tag] || "latest"
-  sh "cat ruby.yaml.in | " \
-    "sed -e \"s|\\$PROJECT|#{project}|g\" | " \
-    "sed -e \"s|\\$TAG|#{tag}|g\" | " \
-    "cat > ruby.yaml"
+  sh "./build_pipeline.sh #{tag} #{project}"
+end
+
+desc "Build the pipeline and all steps to a given tag and project"
+task "build", :tag, :project do |t, args|
+  tag = args[:tag] || DEFAULT_TAG
+  project = args[:project] || DEFAULT_PROJECT
+  sh "./build.sh #{tag} #{project}"
 end
 
 Rake::TestTask.new "test:only" do |t|

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+export TAG=$1
+export PROJECT=$2
+
+if [ -z "$TAG" -o -z "$PROJECT" ]; then
+  echo "Usage: ./build.sh <tag> <project>"
+  echo "Please provide release tag and project name."
+  exit 1
+fi
+
+./build_gen_dockerfile.sh $TAG $PROJECT
+./build_build_app.sh $TAG $PROJECT
+./build_pipeline.sh $TAG $PROJECT

--- a/builder/build_build_app.sh
+++ b/builder/build_build_app.sh
@@ -2,14 +2,22 @@
 
 set -e
 
-export IMAGE=$1
+export TAG=$1
+export PROJECT=$2
+export BASE_TAG=$3
 
-if [ -z "$1" ]; then
-  echo "Usage: ./build_build_app.sh <image_path>"
-  echo "Please provide fully qualified path to target image."
+if [ -z "$TAG" -o -z "$PROJECT" ]; then
+  echo "Usage: ./build_build_app.sh <tag> <project> [<basetag>]"
+  echo "Please provide release tag and project name."
   exit 1
+fi
+if [ -z "$BASE_TAG" ]; then
+  export BASE_TAG=$TAG
 fi
 
 cd build_steps
-sed -e "s|\$IMAGE|${IMAGE}|g" < build_app.yaml.in > build_app.yaml
+sed -e "s|\$PROJECT|${PROJECT}|g; s|\$TAG|${TAG}|g" \
+  < build_app.yaml.in > build_app.yaml
+sed -e "s|\$BASE_TAG|${BASE_TAG}|g" \
+  < build_app/Dockerfile.in > build_app/Dockerfile
 gcloud alpha container builds create . --config=build_app.yaml

--- a/builder/build_gen_dockerfile.sh
+++ b/builder/build_gen_dockerfile.sh
@@ -2,14 +2,22 @@
 
 set -e
 
-export IMAGE=$1
+export TAG=$1
+export PROJECT=$2
+export BASE_TAG=$3
 
-if [ -z "$1" ]; then
-  echo "Usage: ./build_gen_dockerfile.sh <image_path>"
-  echo "Please provide fully qualified path to target image."
+if [ -z "$TAG" -o -z "$PROJECT" ]; then
+  echo "Usage: ./build_gen_dockerfile.sh <tag> <project> [<basetag>]"
+  echo "Please provide release tag and project name."
   exit 1
+fi
+if [ -z "$BASE_TAG" ]; then
+  export BASE_TAG=$TAG
 fi
 
 cd build_steps
-sed -e "s|\$IMAGE|${IMAGE}|g" < gen_dockerfile.yaml.in > gen_dockerfile.yaml
+sed -e "s|\$PROJECT|${PROJECT}|g; s|\$TAG|${TAG}|g" \
+  < gen_dockerfile.yaml.in > gen_dockerfile.yaml
+sed -e "s|\$BASE_TAG|${BASE_TAG}|g" \
+  < gen_dockerfile/Dockerfile.in > gen_dockerfile/Dockerfile
 gcloud alpha container builds create . --config=gen_dockerfile.yaml

--- a/builder/build_pipeline.sh
+++ b/builder/build_pipeline.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+export TAG=$1
+export PROJECT=$2
+
+if [ -z "$TAG" -o -z "$PROJECT" ]; then
+  echo "Usage: ./build_pipeline.sh <tag> <project>"
+  echo "Please provide release tag and project name."
+  exit 1
+fi
+
+mkdir -p pipeline
+sed -e "s|\$PROJECT|${PROJECT}|g; s|\$TAG|${TAG}|g" \
+  < ruby.yaml.in > pipeline/ruby.yaml

--- a/builder/build_steps/build_app.yaml.in
+++ b/builder/build_steps/build_app.yaml.in
@@ -1,6 +1,6 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '--pull', '--no-cache', '-t', '$IMAGE', '-f', 'build_app/Dockerfile', '.']
+    args: ['build', '--pull', '--no-cache', '-t', 'gcr.io/$PROJECT/ruby-build-app:$TAG', '-f', 'build_app/Dockerfile', '.']
 
 images:
-  - '$IMAGE'
+  - 'gcr.io/$PROJECT/ruby-build-app:$TAG'

--- a/builder/build_steps/build_app/Dockerfile.in
+++ b/builder/build_steps/build_app/Dockerfile.in
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the Ruby base image to get Ruby and its dependencies.
-FROM gcr.io/google_appengine/ruby
+# This builder may need to run Rails build commands, so it uses the Ruby base
+# image to get Ruby and its dependencies.
+FROM gcr.io/google_appengine/ruby:$BASE_TAG
 
-# Install the build script and dockerfile templates.
-RUN mkdir /buildstep
-COPY gen_dockerfile/ /buildstep/
+# Install cloud_sql_proxy in case it is needed by Rails asset precompilation.
+RUN mkdir /buildstep && mkdir /cloudsql
+RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
+        > /buildstep/cloud_sql_proxy \
+    && chmod a+x /buildstep/cloud_sql_proxy
+
+# Install the build scripts.
+COPY build_app/ /buildstep/
 COPY shared/ /buildstep/
 RUN mv /buildstep/run_build_step.sh /buildstep/run_build_step \
     && chmod a+x /buildstep/run_build_step

--- a/builder/build_steps/gen_dockerfile.yaml.in
+++ b/builder/build_steps/gen_dockerfile.yaml.in
@@ -1,6 +1,6 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '--pull', '--no-cache', '-t', '$IMAGE', '-f', 'gen_dockerfile/Dockerfile', '.']
+    args: ['build', '--pull', '--no-cache', '-t', 'gcr.io/$PROJECT/ruby-gen-dockerfile:$TAG', '-f', 'gen_dockerfile/Dockerfile', '.']
 
 images:
-  - '$IMAGE'
+  - 'gcr.io/$PROJECT/ruby-gen-dockerfile:$TAG'

--- a/builder/build_steps/gen_dockerfile/Dockerfile.in
+++ b/builder/build_steps/gen_dockerfile/Dockerfile.in
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This builder may need to run Rails build commands, so it uses the Ruby base
-# image to get Ruby and its dependencies.
-FROM gcr.io/google_appengine/ruby
+# Use the Ruby base image to get Ruby and its dependencies.
+FROM gcr.io/google_appengine/ruby:$BASE_TAG
 
-# Install cloud_sql_proxy in case it is needed by Rails asset precompilation.
-RUN mkdir /buildstep && mkdir /cloudsql
-RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
-        > /buildstep/cloud_sql_proxy \
-    && chmod a+x /buildstep/cloud_sql_proxy
-
-# Install the build scripts.
-COPY build_app/ /buildstep/
+# Install the build script and dockerfile templates.
+RUN mkdir /buildstep
+COPY gen_dockerfile/ /buildstep/
 COPY shared/ /buildstep/
 RUN mv /buildstep/run_build_step.sh /buildstep/run_build_step \
     && chmod a+x /buildstep/run_build_step

--- a/builder/build_steps/gen_dockerfile/templates/Dockerfile.erb
+++ b/builder/build_steps/gen_dockerfile/templates/Dockerfile.erb
@@ -52,8 +52,8 @@ RUN if test -f Gemfile.lock; then \
       && rbenv rehash; \
     fi
 
-# BUG: Reset entrypoint to override base image.
+# Reset entrypoint to override anything set by base image.
 ENTRYPOINT []
 
-# Start application on port $PORT.
-CMD <%= @entrypoint %>
+# Command to start application.
+CMD exec <%= @entrypoint %>

--- a/builder/build_steps/shared/build_info.rb
+++ b/builder/build_steps/shared/build_info.rb
@@ -52,6 +52,7 @@ class BuildInfo
       opts.on "--rbenv-dir=PATH" do |path|
         @rbenv_dir = ::File.absolute_path path
       end
+      yield opts if block_given?
     end.parse! args
     @app_yaml = ::Psych.load_file "#{@workspace_dir}/app.yaml" rescue {}
     @runtime_config = @app_yaml["runtime_config"] || {}

--- a/builder/ruby.yaml.in
+++ b/builder/ruby.yaml.in
@@ -1,5 +1,6 @@
 steps:
   - name: 'gcr.io/$PROJECT/ruby-gen-dockerfile:$TAG'
+    args: ['--base-image-tag', '$TAG', '--enable-packages']
   - name: 'gcr.io/$PROJECT/ruby-build-app:$TAG'
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', '$_OUTPUT_IMAGE', '.']

--- a/builder/test/tc_sample_apps.rb
+++ b/builder/test/tc_sample_apps.rb
@@ -54,10 +54,14 @@ class TestSampleApps < ::Minitest::Test
     end
 
     assert_docker_output \
-        "-v #{TMP_DIR}:/workspace -w /workspace ruby-gen-dockerfile -t",
+        "-v #{TMP_DIR}:/workspace -w /workspace ruby-gen-dockerfile -t" \
+          " --base-image-tag=my-test-tag",
         nil
     assert_file_contents "#{TMP_DIR}/Dockerfile",
-        /ARG REQUESTED_RUBY_VERSION="#{ruby_version}"/
+        [
+          /ARG REQUESTED_RUBY_VERSION="#{ruby_version}"/,
+          /FROM gcr\.io\/google_appengine\/ruby:my-test-tag/
+        ]
     assert_file_contents "#{TMP_DIR}/.dockerignore", /Dockerfile/
 
     assert_docker_output \

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,13 +9,14 @@ module TestHelper
   end
 
   # Assert that the given file contents matches the given string or regex.
-  def assert_file_contents(path, expectation)
+  def assert_file_contents(path, expectations)
     contents = ::IO.read(path)
-    if expectation === contents
-      contents
-    else
-      flunk "File #{path} did not contain #{expectation.inspect}"
+    Array(expectations).each do |expectation|
+      unless expectation === contents
+        flunk "File #{path} did not contain #{expectation.inspect}"
+      end
     end
+    contents
   end
 
   # Assert that execution of the given command produces a zero exit code.


### PR DESCRIPTION
The theme here is to implement versioning support for ruby build steps. This capability ties together a specific version of the base image and specific versions of the build steps by referencing their tags explicitly in the build pipeline config.

Specific changes:
* The entrypoint for the `gen_dockerfile` build step now understands the `--base-image-tag` flag. This lets the pipeline specify the specific base image version to use for an app.
* The scripts for building the build steps now take parameters for the build step version `TAG`, the `PROJECT` name, and the `BASE_TAG` for the base image the step itself is based on. To support this, we had to preprocess the steps' Dockerfiles so `BASE_TAG` is injected into the `FROM` instruction (which otherwise cannot be parameterized).
* There is now a `build_pipeline.sh` script for building the pipeline config. There is now also a `build.sh` script that builds everything. All build operations can now be done without using Rake.
* I simplified the `Rakefile` by removing some build cases that don't seem to be useful.
* The entrypoint for the `gen_dockerfile` build step now understands the `--enable-packages` flag, which explicitly enables the package installation feature. This flag is off by default for now, pending discussion on a cross-language standard/mechanism.
* I used `exec` for generated entrypoints, to make sure signals get mapped to the executable since it is run in a shell.

With this PR, Ruby's build steps are now, AFAICT, fully functional except for the pipeline release process (which is still being designed).