### PR TITLE
Clear base image entrypoint

### DIFF
--- a/appengine/README.md
+++ b/appengine/README.md
@@ -5,7 +5,7 @@
 [Ruby](http://ruby-lang.org) and [Bundler](http://bundler.io), and makes it
 easy to containerize standard [Rack](http://rack.github.io) applications. It
 is used primarily as a base image for deploying Ruby applications to the
-[Google App Engine flexible environment](https://cloud.google.com/appengine/docs/flexible/).
+[Google App Engine flexible environment](https://cloud.google.com/appengine/docs/flexible/ruby/).
 
 ## About this image
 
@@ -13,14 +13,25 @@ This image is designed for Ruby web applications. It does the following:
 
 - It installs a recent version of Debian, the system libraries needed by the
   standard Ruby runtime, and a recent version of [NodeJS](http://nodejs.org).
+- It installs system libraries used by a number of commonly-used ruby gems
+  such as database clients for ActiveRecord adapters. However, the actual
+  list of libraries is subject to change. As a best practice, your downstream
+  Docker image should itself install any Debian packages needed by the ruby
+  gems your application depends on.
 - It installs [rbenv](https://github.com/sstephenson/rbenv) with the
   [ruby-build](https://github.com/sstephenson/ruby-build) plugin.
 - It installs a recent supported version of the standard
   [Ruby interpreter](http://ruby-lang.org/) and configures rbenv to use it by
   default. It also installs a recent version of [bundler](http://bundler.io).
 - It sets the working directory to `/app` and exposes port 8080.
-- It configures a standard `ENTRYPOINT` which runs `rackup` on port 8080,
-  assuming that an appropriate `/app/config.ru` is present.
+- It sets some standard environment variables commonly used for production
+  web applications, especially in a cloud hosting environment. These include:
+  - `PORT=8080`
+  - `RACK_ENV=production`
+  - `RAILS_ENV=production`
+  - `APP_ENV=production`
+  - `RAILS_SERVE_STATIC_FILES=true`
+  - `RAILS_LOG_TO_STDOUT=true`
 
 The following tasks are _not_ handled by this base image, and should be
 performed by your inheriting Dockerfile:
@@ -29,26 +40,30 @@ performed by your inheriting Dockerfile:
 - Install any native libraries needed by required gems.
 - Copy application files into the `/app` directory.
 - Run `bundle install`.
-- Replace `ENTRYPOINT` with a custom application launch command, if desired.
+- Set the `CMD` or `ENTRYPOINT` if desired. (Note the base image leaves these
+  unset.)
 
 ## Usage Example
 
-- Create a Ruby application -- using, for example,
-  [Ruby on Rails](http://rubyonrails.org). The application should include at
-  least the following files:
+First, create a Ruby application. For example, a simple Rack-based application
+might include the following files:
 
-    - `Gemfile` (with at least the Rack gem)
-    - `Gemfile.lock`
-    - `config.ru`
+- `Gemfile` (with at least the Rack gem)
+- `Gemfile.lock`
+- `config.ru`
 
-- Create a Dockerfile in your ruby application directory with the following
-  content.
+Next, create a Dockerfile in your ruby application directory with the following
+content.
 
-        FROM gcr.io/google_appengine/ruby
-        COPY Gemfile Gemfile.lock /app/
-        RUN bundle install && rbenv rehash
-        COPY . /app/
+    FROM gcr.io/google_appengine/ruby
+    COPY . /app/
+    RUN bundle install && rbenv rehash
+    CMD ["bundle", "exec", "rackup", "--port=$PORT", "--env=$RACK_ENV"]
 
-- Run the following command in your application directory:
+Run the following command in your application directory to build the image.
 
-        docker build -t my/app .
+    docker build -t my/app .
+
+Start the server
+
+    docker run -d my/app

--- a/appengine/image_files/Dockerfile
+++ b/appengine/image_files/Dockerfile
@@ -87,16 +87,16 @@ COPY policy.xml /etc/ImageMagick-6/
 # Clean up apt
 RUN apt-get clean && rm -f /var/lib/apt/lists/*_*
 
-# Common configuration for any ENTRYPOINT
-WORKDIR /app
-EXPOSE 8080
-ENV PORT 8080
-CMD []
-
-# Default ENTRYPOINT
+# Common environment variables for framework configuration
 ENV RACK_ENV=production \
     RAILS_ENV=production \
     APP_ENV=production \
     RAILS_SERVE_STATIC_FILES=true \
     RAILS_LOG_TO_STDOUT=true
-ENTRYPOINT bundle exec rackup -p $PORT config.ru -E $RACK_ENV
+
+# Initialize entrypoint
+WORKDIR /app
+EXPOSE 8080
+ENV PORT=8080
+ENTRYPOINT []
+CMD []


### PR DESCRIPTION
Remove the ENTRYPOINT from the base image.

This was a vestige of the pre-beta design where we were using ENTRYPOINT rather than CMD. Currently, the image generated by App Engine Flex during deployment must clear the ENTRYPOINT and set CMD instead. We'd like to clean this up so that images based on this base image don't have to clear the ENTRYPOINT. We also want to match other language base images, which all either use CMD or don't set a default at all.

This is a potential breaking change if any users have a custom image based on the ruby base image that depend on the default ENTRYPOINT setting. I don't expect this would happen commonly if ever, since the Dockerfile generated by `app gen-config --custom` clears the ENTRYPOINT itself. (It would not affect `runtime: ruby` customers at all.) I talked with @JustinBeckwith about this and I think I convinced him it should be okay while we're still in beta. @thagomizer @remi @hxiong388 any objections?