### PR TITLE
Add a few more libraries for common gems

### DIFF
--- a/appengine/image_files/Dockerfile
+++ b/appengine/image_files/Dockerfile
@@ -7,14 +7,17 @@ FROM gcr.io/google_appengine/debian8
 # Install dependencies for Ruby
 # Also installs dependencies for the following common gems:
 #
-# gems      dependencies
+# gems             dependencies
 # ------------------------------------------------------------------
-# curb      libcurl3, libcurl3-gnutls, libcurl4-openssl-dev
-# pg        libpq-dev
-# rmagick   libmagickwand-dev
-# nokogiri  libxml2-dev, libxslt-dev
-# sqlite3   libsqlite3-dev
-# mysql2    libmysqlclient-dev
+# curb             libcurl3, libcurl3-gnutls, libcurl4-openssl-dev
+# pg               libpq-dev
+# rmagick          imagemagick, libmagickwand-dev
+# nokogiri         libxml2-dev, libxslt-dev
+# sqlite3          libsqlite3-dev
+# mysql2           libmysqlclient-dev
+# paperclip        file
+# charlock_holmes  libicu-dev
+# rugged           libgit2-dev
 
 RUN apt-get update -y && \
     apt-get install -y -q --no-install-recommends \
@@ -22,28 +25,31 @@ RUN apt-get update -y && \
         autoconf \
         build-essential \
         ca-certificates \
+        cmake \
         curl \
         git \
         file \
         imagemagick \
-        libffi-dev \
-        libgdbm-dev \
-        libgmp-dev \
-        libncurses5-dev \
-        libqdbm-dev \
-        libreadline6-dev \
-        libssl-dev \
-        libyaml-dev \
-        libz-dev \
-        libxml2-dev \
-        libxslt-dev \
-        libsqlite3-dev \
-        libmysqlclient-dev \
-        libpq-dev \
         libcurl3 \
         libcurl3-gnutls \
         libcurl4-openssl-dev \
+        libffi-dev \
+        libgdbm-dev \
+        libgit2-dev \
+        libgmp-dev \
+        libicu-dev \
         libmagickwand-dev \
+        libmysqlclient-dev \
+        libncurses5-dev \
+        libpq-dev \
+        libqdbm-dev \
+        libreadline6-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libyaml-dev \
+        libz-dev \
         systemtap
 
 # Install node
@@ -52,9 +58,9 @@ ENV PATH /nodejs/bin:$PATH
 
 # Install rbenv
 ENV RBENV_ROOT /rbenv
-RUN git clone https://github.com/sstephenson/rbenv.git /rbenv && \
-    git clone https://github.com/sstephenson/ruby-build.git /rbenv/plugins/ruby-build
-ENV PATH /rbenv/shims:/rbenv/bin:$PATH
+RUN git clone https://github.com/sstephenson/rbenv.git $RBENV_ROOT && \
+    git clone https://github.com/sstephenson/ruby-build.git $RBENV_ROOT/plugins/ruby-build
+ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 
 # Preinstalled default ruby version.
 ENV DEFAULT_RUBY_VERSION 2.3.3

--- a/appengine/test/tc_ruby_versions.rb
+++ b/appengine/test/tc_ruby_versions.rb
@@ -36,6 +36,8 @@ class TestRubyVersions < ::Minitest::Test
     "2.3.1",
     "2.3.2",
     "2.3.3",
+    # 2.4.x versions are currently supported.
+    "2.4.0",
     # Test for no requested version (i.e. fall back to default)
     ""
   ]


### PR DESCRIPTION
Added libicu-dev, libgit2-dev, and cmake to the list of packages installed. This will let App Engine Flex applications install the charlock_holmes and rugged gems (which are in the top 1k based on installs) without needing to break glass with a custom Dockerfile.

Also did a bit of minor cleanup in the dockerfile, and added Ruby 2.4.0 to the list of rubies to test.