### PR TITLE
Change GCR project name to the canonical hyphenated form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ruby-docker
 ===========
 
-This repository contains the source for the `gcr.io/google_appengine/ruby`
+This repository contains the source for the `gcr.io/google-appengine/ruby`
 [Docker](https://docker.com) image. This image is used as a base image for
 Ruby applications running on Google App Engine Flex. For more information,
 see https://cloud.google.com/ruby

--- a/appengine/README.md
+++ b/appengine/README.md
@@ -1,6 +1,6 @@
-# gcr.io/google_appengine/ruby
+# gcr.io/google-appengine/ruby
 
-[`gcr.io/google_appengine/ruby`](http://cloud.google.com/ruby) is a
+[`gcr.io/google-appengine/ruby`](http://cloud.google.com/ruby) is a
 [Docker](https://docker.com) base image that bundles stable versions of
 [Ruby](http://ruby-lang.org) and [Bundler](http://bundler.io), and makes it
 easy to containerize standard [Rack](http://rack.github.io) applications. It
@@ -55,7 +55,7 @@ might include the following files:
 Next, create a Dockerfile in your ruby application directory with the following
 content.
 
-    FROM gcr.io/google_appengine/ruby
+    FROM gcr.io/google-appengine/ruby
     COPY . /app/
     RUN bundle install && rbenv rehash
     CMD ["bundle", "exec", "rackup", "--port=$PORT", "--env=$RACK_ENV"]

--- a/appengine/Rakefile
+++ b/appengine/Rakefile
@@ -1,6 +1,6 @@
 require "rake/testtask"
 
-DEFAULT_PROJECT = "google_appengine"
+DEFAULT_PROJECT = "google-appengine"
 
 ::Dir.chdir ::File.dirname __FILE__
 

--- a/appengine/image_files/Dockerfile
+++ b/appengine/image_files/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfiles for App Engine Ruby apps should inherit FROM this image.
 
 # The base image installs a version of Debian.
-FROM gcr.io/google_appengine/debian8
+FROM gcr.io/google-appengine/debian8
 
 # Install dependencies for Ruby
 # Also installs dependencies for the following common gems:

--- a/builder/build_steps/build_app/Dockerfile.in
+++ b/builder/build_steps/build_app/Dockerfile.in
@@ -14,7 +14,7 @@
 
 # This builder may need to run Rails build commands, so it uses the Ruby base
 # image to get Ruby and its dependencies.
-FROM gcr.io/google_appengine/ruby:$BASE_TAG
+FROM gcr.io/google-appengine/ruby:$BASE_TAG
 
 # Install cloud_sql_proxy in case it is needed by Rails asset precompilation.
 RUN mkdir /buildstep && mkdir /cloudsql

--- a/builder/build_steps/gen_dockerfile/Dockerfile.in
+++ b/builder/build_steps/gen_dockerfile/Dockerfile.in
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the Ruby base image to get Ruby and its dependencies.
-FROM gcr.io/google_appengine/ruby:$BASE_TAG
+FROM gcr.io/google-appengine/ruby:$BASE_TAG
 
 # Install the build script and dockerfile templates.
 RUN mkdir /buildstep

--- a/builder/build_steps/gen_dockerfile/templates/Dockerfile.erb
+++ b/builder/build_steps/gen_dockerfile/templates/Dockerfile.erb
@@ -6,7 +6,7 @@
 # * A recent version of NodeJS
 # * A recent version of the standard Ruby runtime to use by default
 # * The bundler gem
-FROM gcr.io/google_appengine/ruby:<%= @base_image_tag %>
+FROM gcr.io/google-appengine/ruby:<%= @base_image_tag %>
 
 # If your application requires a specific ruby version (compatible with rbenv),
 # set it here. Leave blank to use the currently recommended default.

--- a/builder/test/tc_sample_apps.rb
+++ b/builder/test/tc_sample_apps.rb
@@ -60,7 +60,7 @@ class TestSampleApps < ::Minitest::Test
     assert_file_contents "#{TMP_DIR}/Dockerfile",
         [
           /ARG REQUESTED_RUBY_VERSION="#{ruby_version}"/,
-          /FROM gcr\.io\/google_appengine\/ruby:my-test-tag/
+          /FROM gcr\.io\/google-appengine\/ruby:my-test-tag/
         ]
     assert_file_contents "#{TMP_DIR}/.dockerignore", /Dockerfile/
 

--- a/obsolete/Dockerfile
+++ b/obsolete/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_appengine/base
+FROM gcr.io/google-appengine/base
 
 ENV MESSAGE \\n\
 ********************************** NOTICE **********************************\\n\
@@ -8,7 +8,7 @@ ENV MESSAGE \\n\
   If you want to deploy a Ruby application to Google App Engine, you can\\n\
   simply specify "runtime: ruby" in your app.yaml configuration file.\\n\
   If you'd like to extend the Ruby runtime for App Engine, use\\n\
-  "gcr.io/google_appengine/ruby" as the base image.\\n\
+  "gcr.io/google-appengine/ruby" as the base image.\\n\
   See http://cloud.google.com/ruby for more information on running Ruby on\\n\
   Google Cloud Platform.\\n\
 \\n\

--- a/obsolete/README.md
+++ b/obsolete/README.md
@@ -8,7 +8,7 @@ The following images are now obsolete:
 
 If you want to deploy a Ruby application to Google App Engine, you can simply specify "runtime: ruby" in your app.yaml configuration file.
 
-If you'd like to extend the Ruby runtime for App Engine, use "gcr.io/google_appengine/ruby" as the base image.
+If you'd like to extend the Ruby runtime for App Engine, use "gcr.io/google-appengine/ruby" as the base image.
 
 See http://cloud.google.com/ruby for more information on using Ruby on Google Cloud Platform.
 


### PR DESCRIPTION
These forms are equivalent, but GCR team recommends the hyphens over underscores for consistency.