### PR TITLE
Update build pipeline to match latest versions and packages proposals

### DIFF
--- a/builder/build_pipeline.sh
+++ b/builder/build_pipeline.sh
@@ -13,4 +13,5 @@ fi
 
 mkdir -p pipeline
 sed -e "s|\$PROJECT|${PROJECT}|g; s|\$TAG|${TAG}|g" \
-  < ruby.yaml.in > pipeline/ruby.yaml
+  < ruby.yaml.in > pipeline/ruby-$TAG.yaml
+echo -n $TAG > pipeline/ruby.version

--- a/builder/build_steps/gen_dockerfile/build_script.rb
+++ b/builder/build_steps/gen_dockerfile/build_script.rb
@@ -17,7 +17,7 @@
 require_relative "build_info.rb"
 
 class BuildScript
-  DEFAULT_BASE_IMAGE_TAG = "latest"
+  DEFAULT_BASE_IMAGE_TAG = "staging"
   DEFAULT_ENTRYPOINT = "bundle exec rackup -p $PORT"
 
   def initialize args
@@ -37,7 +37,7 @@ class BuildScript
   end
 
   def main
-    packages = @build.runtime_config["packages"] if @enable_packages
+    packages = @build.app_yaml["packages"] if @enable_packages
     packages ||= []
     entrypoint =
         @build.runtime_config["entrypoint"] ||

--- a/builder/ruby.yaml.in
+++ b/builder/ruby.yaml.in
@@ -1,7 +1,7 @@
 steps:
+  - name: 'gcr.io/$PROJECT/ruby-build-app:$TAG'
   - name: 'gcr.io/$PROJECT/ruby-gen-dockerfile:$TAG'
     args: ['--base-image-tag', '$TAG', '--enable-packages']
-  - name: 'gcr.io/$PROJECT/ruby-build-app:$TAG'
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
 images:


### PR DESCRIPTION
Includes the following:
* Generates versioned runtime pipeline definitions.
* Move app build tasks (such as asset precompilation) before Dockerfile generation in the build pipeline.
* Debian packages now specified by a toplevel "packages" field in app.yaml rather than a subfield of "runtime_config"