### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
-ruby-docker
-===========
+# Ruby Runtime for Google Cloud Platform
 
-This repository contains the source for the `gcr.io/google-appengine/ruby`
-[Docker](https://docker.com) image. This image is used as a base image for
-Ruby applications running on Google App Engine Flex. For more information,
-see https://cloud.google.com/ruby
+[![Travis-CI Build Status](https://travis-ci.org/GoogleCloudPlatform/ruby-docker.svg)](https://travis-ci.org/GoogleCloudPlatform/ruby-docker/)
+
+This repository contains the source for the Ruby runtime for
+[Google App Engine Flexible](https://cloud.google.com/appengine/docs/flexible/).
+It comprises:
+
+* The base image `gcr.io/google-appengine/ruby` in the `appengine` directory.
+* The Ruby runtime build pipeline in the `builder` directory.
+
+For more information on using the Ruby runtime, see
+https://cloud.google.com/ruby
+
+## Contributing changes
+
+* See [CONTRIB.md](CONTRIB.md)
+
+## License
+
+* See [LICENSE](LICENSE)

--- a/appengine/README.md
+++ b/appengine/README.md
@@ -4,23 +4,78 @@
 [Docker](https://docker.com) base image that bundles stable versions of
 [Ruby](http://ruby-lang.org) and [Bundler](http://bundler.io), and makes it
 easy to containerize standard [Rack](http://rack.github.io) applications. It
-is used primarily as a base image for deploying Ruby applications to the
-[Google App Engine flexible environment](https://cloud.google.com/appengine/docs/flexible/ruby/).
+is used primarily as the base image for deploying Ruby applications to
+[Google App Engine Flexible](https://cloud.google.com/appengine/docs/flexible/).
+It may also be used as a base image for running applications on
+[Google Container Engine](https://cloud.google.com/container-engine) or any
+other Docker host.
 
-## About this image
+## Usage
+
+### With App Engine Flexible
+
+App Engine Flexible supports any Ruby web application that uses
+[Bundler](http://bundler.io) and thus has a `Gemfile`.
+
+Often you can deploy a Ruby application to App Engine Flexible without having
+to interact with Docker at all, by specifying `runtime: ruby` in your `app.yaml`
+configuration file. For example:
+
+```yaml
+runtime: ruby
+env: flex
+entrypoint: bundle exec rackup -p $PORT
+
+env_variables:
+  SECRET_KEY_BASE: "1234567890MyLongSecretKey"
+```
+
+See the [documentation](https://cloud.google.com/appengine/docs/flexible/ruby/)
+for more details on deploying Ruby applications to Google App Engine Flexible.
+
+If you are using a
+[custom runtime](https://cloud.google.com/appengine/docs/flexible/custom-runtimes/)
+for a Ruby application, you may also use this image as the base image for your
+Dockerfile.
+
+### With Container Engine or other Docker hosts
+
+For other Docker hosts, you'll need to create a Dockerfile based on this image
+that copies your application code, installs dependencies, and declares a
+command or entrypoint.
+
+For example, if you have a Rack-based application with a `config.ru` file, you
+may use the following Dockerfile:
+
+    # Use the Ruby base image
+    FROM gcr.io/google-appengine/ruby:latest
+
+    # Copy application files and install the bundle
+    COPY . /app/
+    RUN bundle install && rbenv rehash
+
+    # Default container command invokes rackup to start the server.
+    CMD ["bundle", "exec", "rackup", "--port=8080"]
+
+See the next section on the design of the base image for more information on
+what your Dockerfile should do.
+
+## About the Ruby image
+
+### Base image contents
 
 This image is designed for Ruby web applications. It does the following:
 
 - It installs a recent version of Debian, the system libraries needed by the
   standard Ruby runtime, and a recent version of [NodeJS](http://nodejs.org).
 - It installs system libraries used by a number of commonly-used ruby gems
-  such as database clients for ActiveRecord adapters. However, the actual
-  list of libraries is subject to change. As a best practice, your downstream
+  such as database clients for ActiveRecord adapters. However, you should not
+  depend on the actual list of libraries. As a best practice, your downstream
   Docker image should itself install any Debian packages needed by the ruby
   gems your application depends on.
 - It installs [rbenv](https://github.com/sstephenson/rbenv) with the
   [ruby-build](https://github.com/sstephenson/ruby-build) plugin.
-- It installs a recent supported version of the standard
+- It installs a recent supported version of the standard "MRI"
   [Ruby interpreter](http://ruby-lang.org/) and configures rbenv to use it by
   default. It also installs a recent version of [bundler](http://bundler.io).
 - It sets the working directory to `/app` and exposes port 8080.
@@ -34,36 +89,46 @@ This image is designed for Ruby web applications. It does the following:
   - `RAILS_LOG_TO_STDOUT=true`
 
 The following tasks are _not_ handled by this base image, and should be
-performed by your inheriting Dockerfile:
+performed by your downstream Dockerfile:
 
-- Use rbenv to install and select a custom ruby runtime, if desired.
+- Use rbenv to install and select a specific ruby version, if you do not want
+  to use the provided default.
 - Install any native libraries needed by required gems.
 - Copy application files into the `/app` directory.
 - Run `bundle install`.
 - Set the `CMD` or `ENTRYPOINT` if desired. (Note the base image leaves these
   unset.)
 
-## Usage Example
+### Building the base image
 
-First, create a Ruby application. For example, a simple Rack-based application
-might include the following files:
+Google regularly builds and releases this image at
+`gcr.io/google-appengine/ruby`.
 
-- `Gemfile` (with at least the Rack gem)
-- `Gemfile.lock`
-- `config.ru`
+You may build the image yourself using the provided Rake tasks. To build the
+image locally:
 
-Next, create a Dockerfile in your ruby application directory with the following
-content.
+    rake build:local[$YOUR_IMAGE_NAME]
 
-    FROM gcr.io/google-appengine/ruby
-    COPY . /app/
-    RUN bundle install && rbenv rehash
-    CMD ["bundle", "exec", "rackup", "--port=$PORT", "--env=$RACK_ENV"]
+Replace the shell variable with the name and optional tag you wish to use.
+The parameter is optional and will default to `appengine-ruby-base` if not set.
 
-Run the following command in your application directory to build the image.
+To build and install in the Google Container Registry, you need the
+[GCloud SDK](https://cloud.google.com/sdk) installed and configured and
+authenticated for your project. Then run:
 
-    docker build -t my/app .
+    rake build:project[$YOUR_PROJECT,$YOUR_TAG]
 
-Start the server
+Replace the shell variables with the ID of your project and the tag you wish
+to use. The image name will be `ruby`.
 
-    docker run -d my/app
+You may do a local build and run the tests against it using:
+
+    rake test
+
+### Contributing changes
+
+See the CONTRIB.md file at the root of this repository.
+
+### License
+
+See the LICENSE file at the root of this repository.


### PR DESCRIPTION
Flesh out the base image README a bit more to address https://github.com/GoogleCloudPlatform/ruby-docker/issues/75, and update the main README to indicate the two main parts of the runtime.