### PR TITLE
Allow array entrypoints, and suppress exec if not safe

### DIFF
--- a/builder/build_steps/gen_dockerfile/templates/Dockerfile.erb
+++ b/builder/build_steps/gen_dockerfile/templates/Dockerfile.erb
@@ -56,4 +56,4 @@ RUN if test -f Gemfile.lock; then \
 ENTRYPOINT []
 
 # Command to start application.
-CMD exec <%= @entrypoint %>
+CMD <%= @entrypoint %>

--- a/builder/test/sample_apps/rack_app/app.yaml
+++ b/builder/test/sample_apps/rack_app/app.yaml
@@ -1,3 +1,2 @@
 runtime: ruby
 env: flex
-entrypoint: bundle exec rackup -p 8080 -E production config.ru

--- a/builder/test/sample_apps/rails4_app/app.yaml
+++ b/builder/test/sample_apps/rails4_app/app.yaml
@@ -1,3 +1,3 @@
 runtime: ruby
 env: flex
-entrypoint: bundle exec bin/rails s
+entrypoint: [ "bundle", "exec", "bin/rails", "s" ]

--- a/builder/test/tc_sample_apps.rb
+++ b/builder/test/tc_sample_apps.rb
@@ -28,18 +28,26 @@ class TestSampleApps < ::Minitest::Test
 
   def test_rack_app
     run_app_test "rack_app"
+    assert_file_contents "#{TMP_DIR}/Dockerfile",
+        /CMD \["bundle","exec","rackup","-p","8080"\]/
   end
 
   def test_sinatra1_app
     run_app_test "sinatra1_app", ruby_version: "2.3.3"
+    assert_file_contents "#{TMP_DIR}/Dockerfile",
+        /CMD exec bundle exec ruby myapp\.rb -p \$PORT/
   end
 
   def test_rails5_app
     run_app_test "rails5_app", ruby_version: "2.3.1", has_assets: true
+    assert_file_contents "#{TMP_DIR}/Dockerfile",
+        /CMD exec bundle exec bin\/rails s/
   end
 
   def test_rails4_app
     run_app_test "rails4_app", has_assets: true
+    assert_file_contents "#{TMP_DIR}/Dockerfile",
+        /CMD \["bundle","exec","bin\/rails","s"\]/
   end
 
   def run_app_test app_name, ruby_version: "", has_assets: false


### PR DESCRIPTION
Improvements for entrypoint handling in the runtime builder (does not affect pre-builder behavior). Currently, gen-dockerfile indiscriminately prepends "exec" to an entrypoint, in an attempt to forward signals properly to the process running in the container. This fails in a variety of cases, including:
* the entrypoint already begins with "exec"
* the entrypoint begins with a shell builtin such as "cd"
* the entrypoint runs several binaries separated by `;`, `&&`, `||`, or `|`.

This updates the logic to avoid prepending "exec" in cases when it is likely to fail. We still do prepend it by default because that is the current behavior of the pre-builder external runtimes system, and because it is the right thing to do in the common case.

We also now support array (i.e. Dockerfile "exec" format) specification of an entrypoint, which is another way to get signal propagation to work properly for people who understand Docker. e.g. in app.yaml:
```
entrypoint: ["bundle", "exec", "bin/rails", "s"]
```
