### PR TITLE
Path to the builder working directory can be other than /workspace

### DIFF
--- a/builder/build_steps/shared/run_build_step.sh
+++ b/builder/build_steps/shared/run_build_step.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# When CloudBuild runs this script via docker run, it sets the dir to
-# /workspace, which may have a .ruby-version that is not supported by the
-# base image. So cd back into /build-step before running Ruby.
+# When CloudBuild runs this script via docker run, it sets the dir to the
+# workspace, which may have a .ruby-version that is not supported by the
+# base image. So cd back into /buildstep before running Ruby, and pass the
+# original working directory into the script.
+WORKSPACE_DIR=$(/bin/pwd)
 cd /buildstep
-ruby build_script.rb "$@"
+ruby build_script.rb --workspace-dir=$WORKSPACE_DIR "$@"


### PR DESCRIPTION
Don't depend on the path `/workspace`. Instead, pass the actual working directory into the build scripts.