### PR TITLE
Ensure requested env variables are set during builds

### DIFF
--- a/builder/build_steps/build_app/build_script.rb
+++ b/builder/build_steps/build_app/build_script.rb
@@ -31,6 +31,7 @@ class BuildScript
     unless build_scripts.empty?
       install_binaries
       install_bundle
+      setup_env_variables
       start_services
       run_build_scripts build_scripts
       stop_services
@@ -95,6 +96,12 @@ class BuildScript
     end
   end
 
+  def setup_env_variables
+    @build.env_variables.each do |k, v|
+      ENV[k.to_s] = v.to_s
+    end
+  end
+
   def start_services
     @cloudsql_proxy_pid = nil
     proxy_ok = false
@@ -123,9 +130,7 @@ class BuildScript
   def stop_services
     if @cloudsql_proxy_pid
       @build.log "Shutting down CloudSQL Proxy"
-      ::Process.kill "INT", @cloudsql_proxy_pid
-      ::Process.wait @cloudsql_proxy_pid
-      @build.log "CloudSQL Proxy is down"
+      ::Process.kill "KILL", @cloudsql_proxy_pid
     end
   end
 

--- a/builder/build_steps/shared/build_info.rb
+++ b/builder/build_steps/shared/build_info.rb
@@ -36,6 +36,7 @@ class BuildInfo
   attr_reader :rbenv_dir
   attr_reader :app_yaml_path
   attr_reader :app_config
+  attr_reader :env_variables
   attr_reader :runtime_config
   attr_reader :ruby_version
 
@@ -59,6 +60,7 @@ class BuildInfo
     @app_yaml_path = ::ENV["GAE_APPLICATION_YAML_PATH"] || DEFAULT_APP_YAML_PATH
     @app_config =
       ::Psych.load_file "#{@workspace_dir}/#{@app_yaml_path}" rescue {}
+    @env_variables = @app_config["env_variables"] || {}
     @runtime_config = @app_config["runtime_config"] || {}
     @ruby_version = ::File.read("#{@workspace_dir}/.ruby-version") rescue ''
     @ruby_version.strip!


### PR DESCRIPTION
The `env_variables` provided by app.yaml need to be honored during build steps.
Also, `cloud_sql_proxy` doesn't seem to respond to SIGINT—it hangs the build—so just kill it instead.