### PR TITLE
Builder starts cloud_sql_proxy only for explicitly requested instances

### DIFF
--- a/builder/build_pipeline.sh
+++ b/builder/build_pipeline.sh
@@ -38,9 +38,12 @@ $DIRNAME/build.sh -i $BASE_IMAGE_TAG -t $BUILDER_TAG
 mkdir -p $DIRNAME/pipeline
 sed -e "s|\$PROJECT|${PROJECT}|g; s|\$BUILDER_TAG|${BUILDER_TAG}|g; s|\$BASE_IMAGE_TAG|${BASE_IMAGE_TAG}|g" \
   < $DIRNAME/ruby.yaml.in > $DIRNAME/pipeline/ruby-$BUILDER_TAG.yaml
+sed -e "s|\$BUILDER_TAG|${BUILDER_TAG}|g" \
+  < $DIRNAME/runtimes.yaml.in > $DIRNAME/pipeline/runtimes.yaml
 echo -n $BUILDER_TAG > $DIRNAME/pipeline/ruby.version
 
 if [ -n "$UPLOAD_BUCKET" ]; then
   gsutil cp $DIRNAME/pipeline/ruby-$BUILDER_TAG.yaml gs://$UPLOAD_BUCKET/ruby-$BUILDER_TAG.yaml
+  gsutil cp $DIRNAME/pipeline/runtimes.yaml gs://$UPLOAD_BUCKET/runtimes.yaml
   gsutil cp $DIRNAME/pipeline/ruby.version gs://$UPLOAD_BUCKET/ruby.version
 fi

--- a/builder/build_step.sh
+++ b/builder/build_step.sh
@@ -11,7 +11,7 @@ BUILDER_TAG="same"
 STAGING_FLAG=
 
 show_usage() {
-  echo "Usage: ./build.sh <step> [-i <base-image-tag>] [-t <builder-tag>] [-s]" >&2
+  echo "Usage: ./build_step.sh <step> [-i <base-image-tag>] [-t <builder-tag>] [-s]" >&2
   echo '<step> can be either "build_app" or "gen_dockerfile"'
   echo "Flags:" >&2
   echo '  -i: set the base image tag (defaults to latest, or use "staging")' >&2

--- a/builder/build_steps/build_app/build_script.rb
+++ b/builder/build_steps/build_app/build_script.rb
@@ -104,13 +104,15 @@ class BuildScript
 
   def start_services
     @cloudsql_proxy_pid = nil
+    sql_instances = @build.cloud_sql_instances.join(',')
+    return if sql_instances.empty?
     proxy_ok = false
     begin
       auth_token = get_auth_token
-      project_id = get_project_id
       @build.log "Starting CloudSQL Proxy..."
+      @build.log "Connecting to #{sql_instances}"
       cmd = "#{@build.builder_dir}/cloud_sql_proxy -dir=/cloudsql " +
-        "-token='#{auth_token}' -projects=#{project_id}"
+        "-token='#{auth_token}' -instances=#{sql_instances}"
       io = ::IO.popen cmd, "r", err: [:child, :out]
       @cloudsql_proxy_pid = io.pid
       io.each_line do |line|
@@ -147,16 +149,8 @@ class BuildScript
     json = `#{cmd}`
     raise "Unable to get auth token" unless json.start_with? '{"'
     token_data = JSON.parse json
-    @build.log "Access token expires in #{token_data["expires_in"]} secs."
+    @build.log "Access token expires in #{token_data["expires_in"]} ms."
     token_data["access_token"]
-  end
-
-  def get_project_id
-    cmd = 'curl -H "Metadata-Flavor: Google" http://metadata.google.internal/' +
-      'computeMetadata/v1/project/project-id'
-    result = `#{cmd}`
-    raise "Unable to get project ID" if result.start_with? '<!DOCTYPE'
-    result
   end
 end
 

--- a/builder/build_steps/shared/build_info.rb
+++ b/builder/build_steps/shared/build_info.rb
@@ -37,6 +37,7 @@ class BuildInfo
   attr_reader :app_yaml_path
   attr_reader :app_config
   attr_reader :env_variables
+  attr_reader :cloud_sql_instances
   attr_reader :runtime_config
   attr_reader :ruby_version
 
@@ -62,6 +63,8 @@ class BuildInfo
       ::Psych.load_file "#{@workspace_dir}/#{@app_yaml_path}" rescue {}
     @env_variables = @app_config["env_variables"] || {}
     @runtime_config = @app_config["runtime_config"] || {}
+    beta_settings = @app_config["beta_settings"] || {}
+    @cloud_sql_instances = Array(beta_settings["cloud_sql_instances"])
     @ruby_version = ::File.read("#{@workspace_dir}/.ruby-version") rescue ''
     @ruby_version.strip!
     ::Dir.chdir workspace_dir

--- a/builder/runtimes.yaml.in
+++ b/builder/runtimes.yaml.in
@@ -1,0 +1,6 @@
+schema_version: 1
+
+runtimes:
+  ruby:
+    target:
+      file: ruby-$BUILDER_TAG.yaml


### PR DESCRIPTION
Previously the build-app step always attempted to start cloud_sql_proxy, and exposed all databases in the project. Now we only expose the database(s) explicitly called out in the app.yaml config, and if there are none, we don't even start cloud_sql_proxy at all.

Also modified the script that builds test pipelines so it updates the new manifest file.