### PR TITLE
Add global .gemrc to base image

### DIFF
--- a/appengine/image_files/.gemrc
+++ b/appengine/image_files/.gemrc
@@ -1,0 +1,2 @@
+install: --no-document --quiet
+update: --no-document --quiet

--- a/appengine/image_files/Dockerfile
+++ b/appengine/image_files/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
         systemtap
 
 # Install node
-RUN mkdir /nodejs && curl https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+RUN mkdir /nodejs && curl -s https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 ENV PATH /nodejs/bin:$PATH
 
 # Install rbenv
@@ -69,16 +69,19 @@ ENV BUNDLER_VERSION 1.15.1
 # Set ruby runtime distribution
 ARG RUNTIME_DISTRIBUTION="ruby-runtime-jessie"
 
+# Default gem installation options
+COPY .gemrc /root/.gemrc
+
 # Install the default ruby binary and bundler.
 RUN (echo "deb http://packages.cloud.google.com/apt ${RUNTIME_DISTRIBUTION} main" \
       | tee /etc/apt/sources.list.d/ruby-runtime-jessie.list) && \
-    (curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    (curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg \
       | apt-key add -) && \
     apt-get update -y && \
     apt-get install -y -q gcp-ruby-$DEFAULT_RUBY_VERSION && \
     rbenv rehash && \
     rbenv global $DEFAULT_RUBY_VERSION && \
-    gem install -q --no-rdoc --no-ri bundler --version $BUNDLER_VERSION && \
+    gem install bundler --version $BUNDLER_VERSION && \
     rbenv rehash
 
 # Tell nokogiri >=1.6 to install using system libraries, for faster builds

--- a/appengine/test/ruby_versions/Dockerfile
+++ b/appengine/test/ruby_versions/Dockerfile
@@ -11,7 +11,7 @@ RUN if test -n "$REQUESTED_RUBY_VERSION" -a \
         && git pull \
         && rbenv install -s $REQUESTED_RUBY_VERSION) \
       && rbenv global $REQUESTED_RUBY_VERSION \
-      && gem install -q --no-rdoc --no-ri bundler --version $BUNDLER_VERSION \
+      && gem install bundler --version $BUNDLER_VERSION \
       && apt-get clean \
       && rm -f /var/lib/apt/lists/*_*; \
     fi

--- a/builder/generate_dockerfile/files/Dockerfile.erb
+++ b/builder/generate_dockerfile/files/Dockerfile.erb
@@ -52,7 +52,7 @@ RUN apt-get install -y -q <%= @app_config.install_packages.join(' ') %>
 #         && git pull \
 #         && rbenv install -s ${REQUESTED_RUBY_VERSION}) \
 #       && rbenv global ${REQUESTED_RUBY_VERSION} \
-#       && gem install -q --no-rdoc --no-ri bundler --version ${BUNDLER_VERSION}; \
+#       && gem install bundler --version ${BUNDLER_VERSION}; \
 #     fi
 <% else %>
 ARG REQUESTED_RUBY_VERSION="<%= @app_config.ruby_version %>"
@@ -62,7 +62,7 @@ RUN if test ! -x /rbenv/versions/${REQUESTED_RUBY_VERSION}/bin/ruby; then \
         && git pull \
         && rbenv install -s ${REQUESTED_RUBY_VERSION}) \
       && rbenv global ${REQUESTED_RUBY_VERSION} \
-      && gem install -q --no-rdoc --no-ri bundler --version ${BUNDLER_VERSION}; \
+      && gem install bundler --version ${BUNDLER_VERSION}; \
     fi
 <% end %>
 


### PR DESCRIPTION
Simplify gem install scripts by providing default flags in a global .gemrc in the base image.