### PR TITLE
Remove obsolete auth workarounds for build environment

### DIFF
--- a/builder/build_pipeline.sh
+++ b/builder/build_pipeline.sh
@@ -12,7 +12,7 @@ show_usage() {
   echo "Usage: ./build.sh [-i <base-image-tag>] [-t <image-tag>] [-b upload-bucket]" >&2
   echo "Flags:" >&2
   echo '  -i: set the base image tag (defaults to latest, or use "staging")' >&2
-  echo '  -t: set the pipeline images tag (defaults to same as base image, or use "new")' >&2
+  echo '  -t: set the pipeline images tag (defaults to "new"; you can also use "same")' >&2
   echo '  -b: set the gs bucket to upload to (omit to skip uploading)' >&2
 }
 
@@ -73,11 +73,11 @@ if [ -z "$PROJECT" ]; then
   exit 1
 fi
 
-$DIRNAME/build_new.sh -i $BASE_IMAGE_TAG -t $IMAGE_TAG
+$DIRNAME/build.sh -i $BASE_IMAGE_TAG -t $IMAGE_TAG
 
 mkdir -p $DIRNAME/pipeline
 sed -e "s|\$PROJECT|${PROJECT}|g; s|\$BUILDER_TAG|${IMAGE_TAG}|g" \
-  < $DIRNAME/ruby-new.yaml.in > $DIRNAME/pipeline/ruby-$IMAGE_TAG.yaml
+  < $DIRNAME/ruby.yaml.in > $DIRNAME/pipeline/ruby-$IMAGE_TAG.yaml
 sed -e "s|\$BUILDER_TAG|${IMAGE_TAG}|g" \
   < $DIRNAME/runtimes.yaml.in > $DIRNAME/pipeline/runtimes.yaml
 echo -n $IMAGE_TAG > $DIRNAME/pipeline/ruby.version

--- a/builder/build_tools/files/access_cloud_sql
+++ b/builder/build_tools/files/access_cloud_sql
@@ -27,16 +27,9 @@ if [ -z "${BUILD_CLOUDSQL_INSTANCES}" ]; then
   fi
 fi
 
-# Should go away after internal issue b/63630627 is fixed.
-if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" -a -n "${GOOGLE_ACCESS_TOKEN_FILE}" ]; then
-  TOKEN_PARAM="-token=$(cat ${GOOGLE_ACCESS_TOKEN_FILE})"
-else
-  TOKEN_PARAM=
-fi
-
 rm -f /build_tools/cloud_sql_proxy.log
 touch /build_tools/cloud_sql_proxy.log
-/build_tools/cloud_sql_proxy -dir=/cloudsql ${TOKEN_PARAM} -instances=${BUILD_CLOUDSQL_INSTANCES} > /build_tools/cloud_sql_proxy.log 2>&1 &
+/build_tools/cloud_sql_proxy -dir=/cloudsql -instances=${BUILD_CLOUDSQL_INSTANCES} > /build_tools/cloud_sql_proxy.log 2>&1 &
 if (timeout ${SQL_TIMEOUT}s tail -f --lines=+1 /build_tools/cloud_sql_proxy.log &) | grep -qe 'Ready for new connections'; then
   echo "Started cloud_sql_proxy."
 else

--- a/builder/generate_dockerfile/files/Dockerfile.erb
+++ b/builder/generate_dockerfile/files/Dockerfile.erb
@@ -110,8 +110,7 @@ ENV <%= k %>="<%= escape_quoted v %>"
 
 ## If your build scripts need access to your application's CloudSQL instances,
 ## list them here, comma-delimited. This environment variable tells the
-## "with_runtime" script to run the CloudSQL Proxy that provides access to
-## your databases.
+## "access_cloud_sql" script which databases to connect to.
 ## Also, make sure the /cloudsql directory is created because the CloudSQL
 ## Proxy will open sockets in that directory.
 <% if @app_config.cloud_sql_instances.empty? %>
@@ -127,13 +126,6 @@ RUN mkdir /cloudsql
 ## GOOGLE_APPLICATION_CREDENTIALS path accordingly:
 # COPY my-build-credentials.json /build_tools/credentials.json
 # ENV GOOGLE_APPLICATION_CREDENTIALS=/build_tools/credentials.json
-<% if @access_token_file %>
-
-## Temporary access token during an App Engine deployment.
-## This should go away after internal issue b/63630627 is fixed.
-RUN mv <%= @access_token_file %> /build_tools/access_token
-ENV GOOGLE_ACCESS_TOKEN_FILE=/build_tools/access_token
-<% end %>
 
 ## If the application uses bundler, install the bundle here.
 <% if @app_config.has_gemfile %>

--- a/builder/ruby-latest.yaml
+++ b/builder/ruby-latest.yaml
@@ -1,7 +1,6 @@
 steps:
   - name: 'gcr.io/gcp-runtimes/ruby/generate-dockerfile:latest'
-    args: ['--capture-access-token']
   - name: 'gcr.io/cloud-builders/docker:latest'
-    args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
+    args: ['build', '--network=cloudbuild', '-t', '$_OUTPUT_IMAGE', '.']
 images:
   - '$_OUTPUT_IMAGE'

--- a/builder/ruby.yaml.in
+++ b/builder/ruby.yaml.in
@@ -1,7 +1,6 @@
 steps:
   - name: 'gcr.io/$PROJECT/ruby/generate-dockerfile:$BUILDER_TAG'
-    args: ['--capture-access-token']
   - name: 'gcr.io/cloud-builders/docker:latest'
-    args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
+    args: ['build', '--network=cloudbuild', '-t', '$_OUTPUT_IMAGE', '.']
 images:
   - '$_OUTPUT_IMAGE'


### PR DESCRIPTION
Prior to July 24, the docker containers that ran runtime build steps didn't provide full access to the correct metadata service (and thus credentials) due to internal issues b/33233310 and b/63630627. As a result, when a build step required the cloud_sql_proxy, we had to employ a workaround that obtained an access token separately and jumped through some hoops to pass it to the cloud_sql_proxy.

Now that b/33233310 and b/63630627 are fixed, all build step containers are connected to a network that includes the correct metadata service. The workaround is no longer necessary---and indeed now seems to be breaking things in a few cases. So this PR removes it.

This PR also includes the following related fixes:

* Fixed builder/build_pipeline.sh which was referencing old script names.
* Modified the default build step generation in builder/generate_dockerfile/files/app_config.rb so it recognizes rcloadenv if it's present in the entrypoint.