### PR TITLE
Combine env instructions in generated Dockerfile

### DIFF
--- a/builder/generate_dockerfile/files/Dockerfile.erb
+++ b/builder/generate_dockerfile/files/Dockerfile.erb
@@ -103,9 +103,7 @@ COPY . /app/
 <% if @app_config.env_variables.empty? %>
 # ENV NAME="value"
 <% else %>
-<% @app_config.env_variables.each do |k, v| %>
-ENV <%= k %>="<%= escape_quoted v %>"
-<% end %>
+ENV <%= render_env @app_config.env_variables %>
 <% end %>
 
 ## If your build scripts need access to your application's CloudSQL instances,

--- a/builder/generate_dockerfile/files/generate_dockerfile.rb
+++ b/builder/generate_dockerfile/files/generate_dockerfile.rb
@@ -107,6 +107,10 @@ class GenerateDockerfile
   def escape_quoted str
     str.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("\n", "\\n")
   end
+
+  def render_env hash
+    hash.map{ |k,v| "#{k}=\"#{escape_quoted v}\"" }.join(" \\\n    ")
+  end
 end
 
 GenerateDockerfile.new(::ARGV).main

--- a/builder/test/test_generate_dockerfile.rb
+++ b/builder/test/test_generate_dockerfile.rb
@@ -75,9 +75,9 @@ class TestGenerateDockerfile < ::Minitest::Test
         VAR3: "\\"quoted\\"\\nnewline"
     CONFIG
     run_generate_dockerfile "rack_app", config: config
-    assert_dockerfile_line "ENV VAR1=\"value1\""
-    assert_dockerfile_line "ENV VAR2=\"with space\""
-    assert_dockerfile_line "ENV VAR3=\"\\\\\"quoted\\\\\"\\\\nnewline\""
+    assert_dockerfile_line "ENV VAR1=\"value1\" \\\\\\n" +
+      "    VAR2=\"with space\" \\\\\\n" +
+      "    VAR3=\"\\\\\"quoted\\\\\"\\\\nnewline\""
   end
 
   def test_sql_instances


### PR DESCRIPTION
Combine environment variables in the generated Dockerfile to reduce the number of layers in case the application has a lot of environment variables.