### PR TITLE
Update to a known good version of Rubygems

### DIFF
--- a/appengine/image_files/Dockerfile
+++ b/appengine/image_files/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
         systemtap
 
 # Install node
-RUN mkdir /nodejs && curl -s https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+RUN mkdir /nodejs && curl -s https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 ENV PATH /nodejs/bin:$PATH
 
 # Install rbenv
@@ -63,8 +63,9 @@ RUN git clone https://github.com/sstephenson/rbenv.git $RBENV_ROOT && \
 ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 
 # Preinstalled default ruby version.
-ENV DEFAULT_RUBY_VERSION 2.3.4
-ENV BUNDLER_VERSION 1.15.3
+ENV DEFAULT_RUBY_VERSION=2.3.4 \
+    DEFAULT_RUBYGEMS_VERSION=2.6.13 \
+    BUNDLER_VERSION=1.15.4
 
 # Set ruby runtime distribution
 ARG RUNTIME_DISTRIBUTION="ruby-runtime-jessie"
@@ -81,6 +82,8 @@ RUN (echo "deb http://packages.cloud.google.com/apt ${RUNTIME_DISTRIBUTION} main
     apt-get install -y -q gcp-ruby-$DEFAULT_RUBY_VERSION && \
     rbenv rehash && \
     rbenv global $DEFAULT_RUBY_VERSION && \
+    (ruby -e "exit(Gem::rubygems_version < Gem::Version.new('$DEFAULT_RUBYGEMS_VERSION') ? 1 : 0)" \
+      || gem update --system $DEFAULT_RUBYGEMS_VERSION) && \
     gem install bundler --version $BUNDLER_VERSION && \
     rbenv rehash
 

--- a/appengine/test/ruby_versions/Dockerfile
+++ b/appengine/test/ruby_versions/Dockerfile
@@ -11,6 +11,8 @@ RUN if test -n "$REQUESTED_RUBY_VERSION" -a \
         && git pull \
         && rbenv install -s $REQUESTED_RUBY_VERSION) \
       && rbenv global $REQUESTED_RUBY_VERSION \
+      && (ruby -e "exit(Gem::rubygems_version < Gem::Version.new('$DEFAULT_RUBYGEMS_VERSION') ? 1 : 0)" \
+        || gem update --system $DEFAULT_RUBYGEMS_VERSION) \
       && gem install bundler --version $BUNDLER_VERSION \
       && apt-get clean \
       && rm -f /var/lib/apt/lists/*_*; \

--- a/builder/generate_dockerfile/files/Dockerfile.erb
+++ b/builder/generate_dockerfile/files/Dockerfile.erb
@@ -52,6 +52,9 @@ RUN apt-get install -y -q <%= @app_config.install_packages.join(' ') %>
 #         && git pull \
 #         && rbenv install -s ${REQUESTED_RUBY_VERSION}) \
 #       && rbenv global ${REQUESTED_RUBY_VERSION} \
+#       && (ruby -e "exit(Gem::rubygems_version < \
+#                    Gem::Version.new('$DEFAULT_RUBYGEMS_VERSION') ? 1 : 0)" \
+#         || gem update --system $DEFAULT_RUBYGEMS_VERSION) \
 #       && gem install bundler --version ${BUNDLER_VERSION}; \
 #     fi
 <% else %>
@@ -62,6 +65,9 @@ RUN if test ! -x /rbenv/versions/${REQUESTED_RUBY_VERSION}/bin/ruby; then \
         && git pull \
         && rbenv install -s ${REQUESTED_RUBY_VERSION}) \
       && rbenv global ${REQUESTED_RUBY_VERSION} \
+      && (ruby -e "exit(Gem::rubygems_version < \
+                   Gem::Version.new('$DEFAULT_RUBYGEMS_VERSION') ? 1 : 0)" \
+        || gem update --system $DEFAULT_RUBYGEMS_VERSION) \
       && gem install bundler --version ${BUNDLER_VERSION}; \
     fi
 <% end %>

--- a/builder/test/test_app_config.rb
+++ b/builder/test/test_app_config.rb
@@ -132,7 +132,7 @@ class TestAppConfig < ::Minitest::Test
     ex = assert_raises AppConfig::Error do
       setup_test config: nil
     end
-    assert_match /Could not read app engine config file:/, ex.message
+    assert_match %r{Could not read app engine config file:}, ex.message
   end
 
   def test_illegal_env_name


### PR DESCRIPTION
This is a proposed response to https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/

We propose:

* Define `DEFAULT_RUBYGEMS_VERSION` which is set to a known good version of Rubygems. Currently it is set to the fixed version referenced in the above article. It will be kept up to date in the same way that the current `DEFAULT_RUBY_VERSION` and `BUNDLER_VERSION` are.
* Any time we install the Ruby VM in the Ruby runtime image (whether the default Ruby installation in the base image, or a custom Ruby installation during App Engine build), we do the following:
    * If the version of Rubygems that came with the Ruby VM installation is _older than_ `DEFAULT_RUBYGEMS_VERSION`, then update Rubygems to `DEFAULT_RUBYGEMS_VERSION` _but no further_.
    * Otherwise, if the version of Rubygems that came with the Ruby VM installation is equal to or newer than `DEFAULT_RUBYGEMS_VERSION`, then retain the VM's newer version.
