### PR TITLE
Support newly released Ruby versions

### DIFF
--- a/appengine/image_files/Dockerfile
+++ b/appengine/image_files/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
         systemtap
 
 # Install node
-RUN mkdir /nodejs && curl -s https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+RUN mkdir /nodejs && curl -s https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 ENV PATH /nodejs/bin:$PATH
 
 # Install rbenv
@@ -63,8 +63,8 @@ RUN git clone https://github.com/sstephenson/rbenv.git $RBENV_ROOT && \
 ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 
 # Preinstalled default ruby version.
-ENV DEFAULT_RUBY_VERSION 2.3.4
-ENV BUNDLER_VERSION 1.15.3
+ENV DEFAULT_RUBY_VERSION 2.3.5
+ENV BUNDLER_VERSION 1.15.4
 
 # Set ruby runtime distribution
 ARG RUNTIME_DISTRIBUTION="ruby-runtime-jessie"

--- a/appengine/test/tc_ruby_versions.rb
+++ b/appengine/test/tc_ruby_versions.rb
@@ -22,15 +22,18 @@ class TestRubyVersions < ::Minitest::Test
     "2.2.5",
     "2.2.6",
     "2.2.7",
+    "2.2.8",
     # 2.3.x versions are currently supported.
     "2.3.0",
     "2.3.1",
     "2.3.2",
     "2.3.3",
     "2.3.4",
+    "2.3.5",
     # 2.4.x versions are currently supported.
     "2.4.0",
     "2.4.1",
+    "2.4.2",
     # Test for no requested version (i.e. fall back to default)
     ""
   ]

--- a/builder/build_tools/Dockerfile.in
+++ b/builder/build_tools/Dockerfile.in
@@ -23,7 +23,7 @@ COPY files/ /app/
 
 # Install NodeJS
 RUN mkdir /app/nodejs \
-    && curl -s https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-x64.tar.gz \
+    && curl -s https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-x64.tar.gz \
       | tar xzf - --directory=/app/nodejs --strip-components=1
 
 # Install Yarn


### PR DESCRIPTION
* Add newly released Ruby versions 2.2.8, 2.3.5, and 2.4.2 to the test suite.
* Set default Ruby version to 2.3.5. Usually I'd like to wait a week for any issues to shake out, but in this case there were some critical security fixes.
* Update NodeJS to the latest LTS (6.11.3), and bundler to the latest stable (1.15.4)
