### PR TITLE
Provide an option to speed up tests; fix some conflicting test class names

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,11 @@ Rake::TestTask.new "test:base:only" do |t|
   t.test_files = FileList['test/tc_base_*.rb']
 end
 
+desc "Run subsequent tests faster by omitting some slow low-priority ones"
+task "faster" do
+  ::ENV["FASTER_TESTS"] = "true"
+end
+
 desc "Build local docker images and run all tests"
 task "test" => ["build", "test:only"]
 

--- a/test/tc_base_image_sample_apps.rb
+++ b/test/tc_base_image_sample_apps.rb
@@ -26,7 +26,7 @@ require_relative "test_helper"
 # the sample app Dockerfiles should all inherit FROM the base image, which
 # will be called "ruby-base".
 
-class TestSampleApps < ::Minitest::Test
+class TestBaseImageSampleApps < ::Minitest::Test
 
   include TestHelper
 
@@ -35,23 +35,27 @@ class TestSampleApps < ::Minitest::Test
   TMP_DIR = ::File.join TEST_DIR, "tmp"
 
 
-  def test_rack_app
-    run_app_test "rack_app", <<~DOCKERFILE
-      FROM ruby-base
-      COPY . /app/
-      RUN bundle install && rbenv rehash
-      ENTRYPOINT bundle exec rackup -p 8080 -E production config.ru
-    DOCKERFILE
-  end
+  unless ::ENV["FASTER_TESTS"]
 
-  def test_rails4_app
-    run_app_test "rails4_app", <<~DOCKERFILE
-      FROM ruby-base
-      COPY . /app/
-      RUN bundle install && rbenv rehash
-      ENV SECRET_KEY_BASE=a12345
-      ENTRYPOINT bundle exec bin/rails server -p 8080
-    DOCKERFILE
+    def test_rack_app
+      run_app_test "rack_app", <<~DOCKERFILE
+        FROM ruby-base
+        COPY . /app/
+        RUN bundle install && rbenv rehash
+        ENTRYPOINT bundle exec rackup -p 8080 -E production config.ru
+      DOCKERFILE
+    end
+
+    def test_rails4_app
+      run_app_test "rails4_app", <<~DOCKERFILE
+        FROM ruby-base
+        COPY . /app/
+        RUN bundle install && rbenv rehash
+        ENV SECRET_KEY_BASE=a12345
+        ENTRYPOINT bundle exec bin/rails server -p 8080
+      DOCKERFILE
+    end
+
   end
 
   def test_rails5_app

--- a/test/tc_base_ruby_versions.rb
+++ b/test/tc_base_ruby_versions.rb
@@ -21,7 +21,7 @@ require_relative "test_helper"
 
 class TestRubyVersions < ::Minitest::Test
 
-  VERSIONS = [
+  COMPLETE_VERSIONS = [
     # 2.0 is obsolete, but we keep it for testing patchlevel notation and
     # installation from source.
     "2.0.0-p648",
@@ -53,6 +53,17 @@ class TestRubyVersions < ::Minitest::Test
     ""
   ]
 
+  FASTER_VERSIONS = [
+    # Test only the latest patch of each supported minor version, plus the
+    # case of no requested version.
+    "2.2.8",
+    "2.3.5",
+    "2.4.2",
+    ""
+  ]
+
+
+  VERSIONS = ::ENV["FASTER_TESTS"] ? FASTER_VERSIONS : COMPLETE_VERSIONS
 
   DOCKERFILE = <<~DOCKERFILE_CONTENT
     FROM ruby-base

--- a/test/tc_sample_app_builds.rb
+++ b/test/tc_sample_app_builds.rb
@@ -17,7 +17,7 @@ require_relative "test_helper"
 require "fileutils"
 
 
-class TestSampleApps < ::Minitest::Test
+class TestSampleAppBuilds < ::Minitest::Test
   include TestHelper
 
   TEST_DIR = ::File.dirname __FILE__
@@ -25,10 +25,20 @@ class TestSampleApps < ::Minitest::Test
   APPS_DIR = ::File.join TEST_DIR, "sample_apps"
   TMP_DIR = ::File.join TEST_DIR, "tmp"
 
-  def test_rack_app
-    run_app_test "rack_app" do |image|
-      assert_docker_output "#{image} test ! -d /app/public/assets", nil
+  unless ::ENV["FASTER_TESTS"]
+
+    def test_rack_app
+      run_app_test "rack_app" do |image|
+        assert_docker_output "#{image} test ! -d /app/public/assets", nil
+      end
     end
+
+    def test_rails4_app
+      run_app_test "rails4_app" do |image|
+        assert_docker_output "#{image} test -d /app/public/assets", nil
+      end
+    end
+
   end
 
   def test_sinatra1_app
@@ -39,12 +49,6 @@ class TestSampleApps < ::Minitest::Test
 
   def test_rails5_app
     run_app_test "rails5_app" do |image|
-      assert_docker_output "#{image} test -d /app/public/assets", nil
-    end
-  end
-
-  def test_rails4_app
-    run_app_test "rails4_app" do |image|
       assert_docker_output "#{image} test -d /app/public/assets", nil
     end
   end


### PR DESCRIPTION
This fixes two test classes that mistakenly had the same name (but happened to work anyway... I think...). Also adds an environment variable that you can set to skip a bunch of slow lower-priority tests to cut the test time to a fraction of its usual length. Use `rake faster test` instead of `rake test` to set that variable and run the smaller set.