### PR TITLE
Make access_cloud_sql explicit in build steps

### DIFF
--- a/ruby-generate-dockerfile/app/Dockerfile.erb
+++ b/ruby-generate-dockerfile/app/Dockerfile.erb
@@ -145,11 +145,7 @@ RUN bundle install --deployment --without="development test" && rbenv rehash
 <% end %>
 <% else %>
 <% @app_config.build_scripts.each do |script| %>
-<% if @app_config.cloud_sql_instances.empty? %>
 RUN <%= script %>
-<% else %>
-RUN /build_tools/access_cloud_sql && <%= script %>
-<% end %>
 <% end %>
 <% end %>
 

--- a/ruby-generate-dockerfile/app/app_config.rb
+++ b/ruby-generate-dockerfile/app/app_config.rb
@@ -96,11 +96,19 @@ class AppConfig
         !::File.file?("#{@workspace_dir}/config/application.rb")
       return []
     end
-    if @entrypoint =~ /(rcloadenv\s.+\s--\s)/
-      ["bundle exec #{$1}rake assets:precompile || true"]
+    [rails_asset_precompile_script]
+  end
+
+  def rails_asset_precompile_script
+    script = if @entrypoint =~ /(rcloadenv\s.+\s--\s)/
+      "bundle exec #{$1}rake assets:precompile || true"
     else
-      ["bundle exec rake assets:precompile || true"]
+      "bundle exec rake assets:precompile || true"
     end
+    unless @cloud_sql_instances.empty?
+      script = "/build_tools/access_cloud_sql && #{script}"
+    end
+    script
   end
 
   def init_cloud_sql_instances

--- a/test/tc_generate_dockerfile.rb
+++ b/test/tc_generate_dockerfile.rb
@@ -103,25 +103,19 @@ class TestGenerateDockerfile < ::Minitest::Test
     assert_dockerfile_line "RUN bundle exec rake do:something:else"
   end
 
-  def test_custom_build_scripts_with_cloud_sql
-    config = <<~CONFIG
-      lifecycle:
-        build:
-          - bundle exec rake do:something
-          - bundle exec rake do:something:else
-      beta_settings:
-        cloud_sql_instances: my-proj:my-region:my-db
-    CONFIG
-    run_generate_dockerfile "rack_app", config: config
-    assert_dockerfile_line "RUN /build_tools/access_cloud_sql &&" \
-        " bundle exec rake do:something"
-    assert_dockerfile_line "RUN /build_tools/access_cloud_sql &&" \
-        " bundle exec rake do:something:else"
-  end
-
   def test_rails_default_build_scripts
     run_generate_dockerfile "rails5_app"
     assert_dockerfile_line "RUN bundle exec rake assets:precompile \\|\\| true"
+  end
+
+  def test_rails_default_build_scripts_with_cloud_sql
+    config = <<~CONFIG
+      beta_settings:
+        cloud_sql_instances: my-proj:my-region:my-db
+    CONFIG
+    run_generate_dockerfile "rails5_app", config: config
+    assert_dockerfile_line "RUN /build_tools/access_cloud_sql &&" \
+        " bundle exec rake assets:precompile \\|\\| true"
   end
 
   def test_entrypoint


### PR DESCRIPTION
Previously the Dockerfile generation for the Ruby runtime always prefaced build steps with `/build_tools/access_cloud_sql` (which starts the cloud_sql_proxy) if there is a CloudSQL instance present in the configuration. This bit of "magic" usually does the right thing, or at least doesn't do any (significant) harm. But it is often unnecessary, and having this extra magic has been making me uncomfortable. It is also inconsistent with how other runtimes that allow configuring of build steps work (e.g. node and elixir).

Changing this so that `/build_tools/access_cloud_sql` must be explicit in the build step (as configured in app.yaml) if it is desired. We adjust the code that computes the default build step (for Rails apps) so it includes `/build_tools/access_cloud_sql` in the computed default if there is a CloudSQL instance present. Thus, if the user leaves everything as default, this change will have no effect. However, if the user customizes the build steps in app.yaml _and_ there is a CloudSQL instance, the customized build steps would have to be modified to include `/build_tools/access_cloud_sql` explicitly. Because we have not documented anywhere that the build steps are customizable, we do not expect anyone to be using this feature yet.