### PR TITLE
Make access_cloud_sql lenient in the default asset precompile step

### DIFF
--- a/ruby-build-tools/access_cloud_sql
+++ b/ruby-build-tools/access_cloud_sql
@@ -18,13 +18,15 @@ set -e
 
 SQL_TIMEOUT=10
 
+if [ "$1" == "--lenient" ]; then
+  ERROR_RESULT=0
+else
+  ERROR_RESULT=1
+fi
+
 if [ -z "${BUILD_CLOUDSQL_INSTANCES}" ]; then
   >&2 echo "ERROR: Invoked access_cloud_sql with no CloudSQL instances available"
-  if [ "$1" == "--lenient" ]; then
-    exit 0
-  else
-    exit 1
-  fi
+  exit ${ERROR_RESULT}
 fi
 
 rm -f /build_tools/cloud_sql_proxy.log
@@ -35,5 +37,5 @@ if (timeout ${SQL_TIMEOUT}s tail -f --lines=+1 /build_tools/cloud_sql_proxy.log 
 else
   >&2 echo "ERROR: Failed to start cloud_sql_proxy"
   >&2 cat /build_tools/cloud_sql_proxy.log
-  exit 1
+  exit ${ERROR_RESULT}
 fi

--- a/ruby-generate-dockerfile/app/Dockerfile.erb
+++ b/ruby-generate-dockerfile/app/Dockerfile.erb
@@ -137,14 +137,14 @@ RUN bundle install --deployment --without="development test" && rbenv rehash
 
 ## Run application build scripts here.
 ## Scripts that require access to the application CloudSQL instances should
-## run /build_tools/access_cloud_sql first to start the cloud_sql_proxy. e.g.
-##   RUN /build_tools/access_cloud_sql && bundle exec rake my_task
+## run access_cloud_sql first to start the cloud_sql_proxy. e.g.
+##   RUN access_cloud_sql && bundle exec rake my_task
 ## Otherwise, simply run each build script in order in a separate RUN command.
 <% if build_scripts.empty? %>
 <% if cloud_sql_instances.empty? %>
 # RUN bundle exec rake assets:precompile
 <% else %>
-# RUN /build_tools/access_cloud_sql && bundle exec rake assets:precompile
+# RUN access_cloud_sql && bundle exec rake assets:precompile
 <% end %>
 <% else %>
 <% build_scripts.each do |script| %>

--- a/ruby-generate-dockerfile/app/app_config.rb
+++ b/ruby-generate-dockerfile/app/app_config.rb
@@ -106,7 +106,7 @@ class AppConfig
       "bundle exec rake assets:precompile || true"
     end
     unless @cloud_sql_instances.empty?
-      script = "/build_tools/access_cloud_sql && #{script}"
+      script = "access_cloud_sql --lenient && #{script}"
     end
     script
   end

--- a/test/tc_generate_dockerfile.rb
+++ b/test/tc_generate_dockerfile.rb
@@ -114,7 +114,7 @@ class TestGenerateDockerfile < ::Minitest::Test
         cloud_sql_instances: my-proj:my-region:my-db
     CONFIG
     run_generate_dockerfile "rails5_app", config: config
-    assert_dockerfile_line "RUN /build_tools/access_cloud_sql &&" \
+    assert_dockerfile_line "RUN access_cloud_sql --lenient &&" \
         " bundle exec rake assets:precompile \\|\\| true"
   end
 


### PR DESCRIPTION
Currently if the sqladmin api is not enabled or the cloudbuild service account doesn't have permissions, then access_cloud_sql will fail with an error in the default rails build step, which means assets won't get precompiled. Most asset precompilation won't actually need to hit the database, and we'd like the default generated build step to work in as many cases as possible, so we'll have it use the lenient behavior where it will continue even if it can't establish the database connection.