### PR TITLE
Provide gcloud to build commands

### DIFF
--- a/ruby-build-tools/Dockerfile
+++ b/ruby-build-tools/Dockerfile
@@ -20,7 +20,7 @@ FROM ruby-base AS builder
 
 # Versions
 ARG NODEJS_VERSION=6.11.4
-ARG GCLOUD_VERSION=176.0.0
+ARG GCLOUD_VERSION=177.0.0
 
 # Install build script files.
 COPY access_cloud_sql /app/

--- a/ruby-build-tools/Dockerfile
+++ b/ruby-build-tools/Dockerfile
@@ -18,12 +18,16 @@
 # Use the Ruby base image as a tool to download things.
 FROM ruby-base AS builder
 
+# Versions
+ARG NODEJS_VERSION=6.11.4
+ARG GCLOUD_VERSION=176.0.0
+
 # Install build script files.
 COPY access_cloud_sql /app/
 
 # Install NodeJS
 RUN mkdir /app/nodejs \
-    && curl -s https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-x64.tar.gz \
+    && curl -s https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.gz \
       | tar xzf - --directory=/app/nodejs --strip-components=1
 
 # Install Yarn
@@ -35,6 +39,12 @@ RUN mkdir /app/yarn \
 RUN curl -s https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
       > /app/cloud_sql_proxy \
     && chmod a+x /app/cloud_sql_proxy
+
+# Install Google Cloud SDK
+RUN curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz \
+      > /app/google-cloud-sdk.tar.gz \
+    && tar xzf google-cloud-sdk.tar.gz \
+    && rm google-cloud-sdk.tar.gz
 
 
 # Generate a minimal image with only the tool files themselves. This image

--- a/ruby-generate-dockerfile/app/Dockerfile.erb
+++ b/ruby-generate-dockerfile/app/Dockerfile.erb
@@ -5,7 +5,7 @@
 ##
 ## Generated at: <%= timestamp %>
 ## From configuration: <%= app_yaml_path %>
-## Project: <%= project_id %>
+## Project: <%= project_id_for_display %>
 ## Service: <%= service_name %>
 ################################################################################
 
@@ -106,6 +106,13 @@ COPY --from=<%= build_tools_image %> /build_tools/ /build_tools/
 ## Ensure the above tools are in the PATH
 ENV PATH /build_tools:/build_tools/google-cloud-sdk/bin:/build_tools/nodejs/bin:/build_tools/yarn/bin:${PATH}
 
+## Set gcloud project here if your build scripts need to use gcloud.
+<% if project_id %>
+RUN gcloud config set project <%= project_id %>
+<% else %>
+# RUN gcloud config set project <%= project_id_for_example %>
+<% end %>
+
 ## Copy the application files.
 COPY . /app/
 
@@ -115,7 +122,7 @@ COPY . /app/
 ## Also, make sure the /cloudsql directory is created because the CloudSQL
 ## Proxy will open sockets in that directory.
 <% if cloud_sql_instances.empty? %>
-# ARG BUILD_CLOUDSQL_INSTANCES="my-project:db-region:db-name"
+# ARG BUILD_CLOUDSQL_INSTANCES="<%= project_id_for_example %>:db-region:db-name"
 # RUN mkdir /cloudsql
 <% else %>
 ARG BUILD_CLOUDSQL_INSTANCES="<%= cloud_sql_instances.join(',') %>"

--- a/ruby-generate-dockerfile/app/Dockerfile.erb
+++ b/ruby-generate-dockerfile/app/Dockerfile.erb
@@ -99,12 +99,12 @@ ENV <%= render_env env_variables %>
 
 FROM augmented-base AS app-build
 
-## Obtain common build tools, including nodejs, yarn, cloud_sql_proxy, and the
-## access_cloud_sql script, from this image.
+## Obtain common build tools, including nodejs, yarn, gcloud, cloud_sql_proxy,
+## and the access_cloud_sql script, from this image.
 COPY --from=<%= build_tools_image %> /build_tools/ /build_tools/
 
 ## Ensure the above tools are in the PATH
-ENV PATH /build_tools:/build_tools/nodejs/bin:/build_tools/yarn/bin:${PATH}
+ENV PATH /build_tools:/build_tools/google-cloud-sdk/bin:/build_tools/nodejs/bin:/build_tools/yarn/bin:${PATH}
 
 ## Copy the application files.
 COPY . /app/

--- a/test/tc_app_config.rb
+++ b/test/tc_app_config.rb
@@ -55,7 +55,9 @@ class TestAppConfig < ::Minitest::Test
     setup_test
     assert_equal TMP_DIR, @app_config.workspace_dir
     assert_equal "./app.yaml", @app_config.app_yaml_path
-    assert_equal "(unknown)", @app_config.project_id
+    assert_nil @app_config.project_id
+    assert_equal "(unknown)", @app_config.project_id_for_display
+    assert_equal "my-project-id", @app_config.project_id_for_example
     assert_equal "default", @app_config.service_name
     assert_equal EMPTY_HASH, @app_config.env_variables
     assert_equal EMPTY_ARRAY, @app_config.cloud_sql_instances

--- a/test/tc_build_tools.rb
+++ b/test/tc_build_tools.rb
@@ -44,6 +44,9 @@ class TestBuildTools < ::Minitest::Test
         assert_docker_output "#{image} /build_tools/cloud_sql_proxy --version",
           /Cloud SQL Proxy/
         assert_docker_output \
+          "#{image} /build_tools/google-cloud-sdk/bin/gcloud --version",
+          /Google Cloud SDK/
+        assert_docker_output \
           "#{image} /build_tools/access_cloud_sql --lenient && echo OK",
           /OK/
       end


### PR DESCRIPTION
Installs the gcloud SDK in the builder image so that build commands can run gcloud, gsutil, and other useful SDK commands during the build phase. Also fixes the project ID determination, which is needed to set the default gcloud project config.