### PR TITLE
Updates to build tools

### DIFF
--- a/ruby-build-tools/Dockerfile
+++ b/ruby-build-tools/Dockerfile
@@ -19,15 +19,15 @@
 FROM ruby-base AS builder
 
 # Versions
-ARG NODEJS_VERSION=8.9.1
-ARG GCLOUD_VERSION=179.0.0
+ARG nodejs_version=8.9.1
+ARG gcloud_version=180.0.1
 
 # Install build script files.
 COPY access_cloud_sql /app/
 
 # Install NodeJS
 RUN mkdir /app/nodejs \
-    && curl -s https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.gz \
+    && curl -s https://nodejs.org/dist/v${nodejs_version}/node-v${nodejs_version}-linux-x64.tar.gz \
       | tar xzf - --directory=/app/nodejs --strip-components=1
 
 # Install Yarn
@@ -41,10 +41,9 @@ RUN curl -s https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
     && chmod a+x /app/cloud_sql_proxy
 
 # Install Google Cloud SDK
-RUN curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz \
-      > /app/google-cloud-sdk.tar.gz \
-    && tar xzf google-cloud-sdk.tar.gz \
-    && rm google-cloud-sdk.tar.gz
+RUN mkdir /app/google-cloud-sdk \
+    && curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${gcloud_version}-linux-x86_64.tar.gz \
+      | tar xzf - --directory=/app/google-cloud-sdk --strip-components=1
 
 
 # Generate a minimal image with only the tool files themselves. This image

--- a/ruby-build-tools/access_cloud_sql
+++ b/ruby-build-tools/access_cloud_sql
@@ -29,13 +29,13 @@ if [ -z "${BUILD_CLOUDSQL_INSTANCES}" ]; then
   exit ${ERROR_RESULT}
 fi
 
-rm -f /build_tools/cloud_sql_proxy.log
-touch /build_tools/cloud_sql_proxy.log
-/build_tools/cloud_sql_proxy -dir=/cloudsql -instances=${BUILD_CLOUDSQL_INSTANCES} > /build_tools/cloud_sql_proxy.log 2>&1 &
-if (timeout ${SQL_TIMEOUT}s tail -f --lines=+1 /build_tools/cloud_sql_proxy.log &) | grep -qe 'Ready for new connections'; then
+rm -f /tmp/cloud_sql_proxy.log
+touch /tmp/cloud_sql_proxy.log
+cloud_sql_proxy -dir=/cloudsql -instances=${BUILD_CLOUDSQL_INSTANCES} > /tmp/cloud_sql_proxy.log 2>&1 &
+if (timeout ${SQL_TIMEOUT}s tail -f --lines=+1 /tmp/cloud_sql_proxy.log &) | grep -qe 'Ready for new connections'; then
   echo "Started cloud_sql_proxy."
 else
   >&2 echo "ERROR: Failed to start cloud_sql_proxy"
-  >&2 cat /build_tools/cloud_sql_proxy.log
+  >&2 cat /tmp/cloud_sql_proxy.log
   exit ${ERROR_RESULT}
 fi


### PR DESCRIPTION
* Update gcloud to version 180.0.1
* access_cloud_sql no longer depends on the /build_tools path.