### PR TITLE
Support dotenv_config

### DIFF
--- a/ruby-generate-dockerfile/app/app_config.rb
+++ b/ruby-generate-dockerfile/app/app_config.rb
@@ -100,6 +100,13 @@ class AppConfig
 
   def init_build_scripts
     raw_build_scripts = @runtime_config["build"]
+    if raw_build_scripts && @runtime_config["dotenv_config"]
+      raise AppConfig::Error,
+        "The `dotenv_config` setting conflicts with the `build` setting." +
+        " If you want to build a dotenv file in your list of custom build" +
+        " steps, try adding the build step: `gem install rcloadenv && rbenv " +
+        " rehash && rcloadenv my-config-name > .env`"
+    end
     @build_scripts = raw_build_scripts ?
         Array(raw_build_scripts) : default_build_scripts
     @build_scripts.each do |script|

--- a/ruby-generate-dockerfile/app/app_config.rb
+++ b/ruby-generate-dockerfile/app/app_config.rb
@@ -67,7 +67,6 @@ class AppConfig
     end
     @runtime_config = @app_config["runtime_config"] || {}
     @beta_settings = @app_config["beta_settings"] || {}
-    @lifecycle = @app_config["lifecycle"] || {}
     @service_name = @app_config["service"] || DEFAULT_SERVICE_NAME
   end
 
@@ -100,7 +99,7 @@ class AppConfig
   end
 
   def init_build_scripts
-    raw_build_scripts = @lifecycle["build"] || @runtime_config["build"]
+    raw_build_scripts = @runtime_config["build"]
     @build_scripts = raw_build_scripts ?
         Array(raw_build_scripts) : default_build_scripts
     @build_scripts.each do |script|
@@ -112,14 +111,13 @@ class AppConfig
   end
 
   def default_build_scripts
-    if !::File.directory?("#{@workspace_dir}/app/assets") ||
-        !::File.file?("#{@workspace_dir}/config/application.rb")
-      return []
-    end
-    [rails_asset_precompile_script]
+    [rails_asset_precompile_script, dotenv_from_rc_script].compact
   end
 
   def rails_asset_precompile_script
+    return nil if !::File.directory?("#{@workspace_dir}/app/assets") ||
+        !::File.file?("#{@workspace_dir}/config/application.rb")
+
     script = if @entrypoint =~ /(rcloadenv\s.+\s--\s)/
       "bundle exec #{$1}rake assets:precompile || true"
     else
@@ -129,6 +127,12 @@ class AppConfig
       script = "access_cloud_sql --lenient && #{script}"
     end
     script
+  end
+
+  def dotenv_from_rc_script
+    config_name = @runtime_config["dotenv_config"].to_s
+    return nil if config_name.empty?
+    "gem install rcloadenv && rbenv rehash && rcloadenv #{config_name} > .env"
   end
 
   def init_cloud_sql_instances

--- a/test/tc_app_config.rb
+++ b/test/tc_app_config.rb
@@ -83,7 +83,6 @@ class TestAppConfig < ::Minitest::Test
       runtime_config:
         foo: bar
         packages: libgeos
-      lifecycle:
         build: bundle exec rake hello
     CONFIG
     setup_test config: config
@@ -121,6 +120,23 @@ class TestAppConfig < ::Minitest::Test
     setup_test dir: "rails"
     assert_equal ["bundle exec rake assets:precompile || true"],
                  @app_config.build_scripts
+  end
+
+  def test_rails_and_dotenv_default_build
+    config = <<~CONFIG
+      env: flex
+      runtime: ruby
+      entrypoint: bundle exec bin/rails s
+      runtime_config:
+        dotenv_config: my-config
+    CONFIG
+    setup_test dir: "rails", config: config
+    assert_equal \
+      [
+        "bundle exec rake assets:precompile || true",
+        "gem install rcloadenv && rbenv rehash && rcloadenv my-config > .env"
+      ],
+      @app_config.build_scripts
   end
 
   def test_ruby_version
@@ -173,7 +189,7 @@ class TestAppConfig < ::Minitest::Test
       env: flex
       runtime: ruby
       entrypoint: bundle exec ruby hello.rb
-      lifecycle:
+      runtime_config:
         build: "multiple\\nlines"
     CONFIG
     ex = assert_raises AppConfig::Error do

--- a/test/tc_app_config.rb
+++ b/test/tc_app_config.rb
@@ -199,6 +199,22 @@ class TestAppConfig < ::Minitest::Test
       ex.message
   end
 
+  def test_dotenv_clashes_with_custom_build
+    config = <<~CONFIG
+      env: flex
+      runtime: ruby
+      entrypoint: bundle exec ruby hello.rb
+      runtime_config:
+        build: ["bundle exec rake hello"]
+        dotenv_config: my-config
+    CONFIG
+    ex = assert_raises AppConfig::Error do
+      setup_test config: config
+    end
+    assert_match /^The `dotenv_config` setting conflicts with the `build`/,
+      ex.message
+  end
+
   def test_illegal_sql_instances
     config = <<~CONFIG
       env: flex

--- a/test/tc_generate_dockerfile.rb
+++ b/test/tc_generate_dockerfile.rb
@@ -93,7 +93,7 @@ class TestGenerateDockerfile < ::Minitest::Test
 
   def test_custom_build_scripts
     config = <<~CONFIG
-      lifecycle:
+      runtime_config:
         build:
           - bundle exec rake do:something
           - bundle exec rake do:something:else
@@ -165,7 +165,7 @@ class TestGenerateDockerfile < ::Minitest::Test
 
   def test_build_scripts_failure
     config = <<~CONFIG
-      lifecycle:
+      runtime_config:
         build:
           - "bundle exec rake do:something\\nwith newline"
     CONFIG


### PR DESCRIPTION
Support the dotenv_config setting in app.yaml, generating a build step that builds a `.env` file from a runtime config resource.