### PR TITLE
Pick up ruby version from gemfile

### DIFF
--- a/ruby-generate-dockerfile/app/app_config.rb
+++ b/ruby-generate-dockerfile/app/app_config.rb
@@ -197,6 +197,12 @@ class AppConfig
   def init_ruby_config
     @ruby_version = ::File.read("#{@workspace_dir}/.ruby-version") rescue ''
     @ruby_version.strip!
+    if @ruby_version == ""
+      result = Dir.chdir(@workspace_dir) { `bundle platform --ruby` }
+      if result.strip =~ %r{^ruby (\d+\.\d+\.\d+)$}
+        @ruby_version = $1
+      end
+    end
     if @ruby_version !~ %r{\A[\w.-]*\z}
       raise AppConfig::Error, "Illegal ruby version: #{@ruby_version.inspect}"
     end

--- a/test/app_config/gemfile-ruby/gems.rb
+++ b/test/app_config/gemfile-ruby/gems.rb
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+ruby "2.0.98"

--- a/test/tc_app_config.rb
+++ b/test/tc_app_config.rb
@@ -144,6 +144,11 @@ class TestAppConfig < ::Minitest::Test
     assert_equal "2.0.99", @app_config.ruby_version
   end
 
+  def test_bundler_ruby_version
+    setup_test dir: "gemfile-ruby"
+    assert_equal "2.0.98", @app_config.ruby_version
+  end
+
   def test_gemfile_old_name
     setup_test dir: "gemfile-old"
     assert @app_config.has_gemfile?


### PR DESCRIPTION
If there isn't a `.ruby-version` file, attempt to get the ruby version from the Gemfile first, before falling back to the default version. This should, among other things, make it easier to move from Heroku.