### PR TITLE
Add libjemalloc-dev to ruby-base

### DIFF
--- a/ruby-base/Dockerfile
+++ b/ruby-base/Dockerfile
@@ -54,6 +54,8 @@ RUN apt-get update -y && \
         libgit2-dev \
         libgmp-dev \
         libicu-dev \
+        libjemalloc-dev \
+        libjemalloc1 \
         libmagickwand-dev \
         libmysqlclient-dev \
         libncurses5-dev \


### PR DESCRIPTION
Using jemalloc can reduce Ruby memory usage by 30%.
It makes sense to include this in the base image.
Ref: https://medium.com/@adrienjarthon/ruby-jemalloc-results-for-updown-io-d3fb2d32f67f