### PR TITLE
Fix GPG error "NO_PUBKEY"

### DIFF
--- a/ruby-generate-dockerfile/app/Dockerfile.erb
+++ b/ruby-generate-dockerfile/app/Dockerfile.erb
@@ -31,7 +31,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 <% if install_packages.empty? && ruby_version.empty? %>
 # RUN apt-get update -y
 <% else %>
-RUN apt-get update -y
+RUN (curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -) && \
+    apt-get update -y
 <% end %>
 
 ## If your application needs to install additional Debian packages, do so here.


### PR DESCRIPTION
On April 2, I encountered the following error.

```
Step #1: Step 3/18 : RUN apt-get update -y
Step #1:  ---> Running in 14284ec85248
Step #1: Get:1 http://security.debian.org jessie/updates InRelease [63.1 kB]
Step #1: Get:2 http://packages.cloud.google.com ruby-runtime-jessie InRelease [3749 B]
Step #1: Ign http://httpredir.debian.org jessie InRelease
Step #1: Get:3 http://httpredir.debian.org jessie-updates InRelease [145 kB]
Step #1: Get:4 http://httpredir.debian.org jessie Release.gpg [2434 B]
Step #1: Get:5 http://httpredir.debian.org jessie Release [148 kB]
Step #1: Get:6 http://security.debian.org jessie/updates/main amd64 Packages [643 kB]
Step #1: Ign http://packages.cloud.google.com ruby-runtime-jessie InRelease
Step #1: Get:7 http://packages.cloud.google.com ruby-runtime-jessie/main amd64 Packages [2756 B]
Step #1: Get:8 http://httpredir.debian.org jessie-updates/main amd64 Packages [23.1 kB]
Step #1: Get:9 http://httpredir.debian.org jessie/main amd64 Packages [9064 kB]
Step #1: Fetched 10.1 MB in 7s (1374 kB/s)
Step #1: Reading package lists...
Step #1: W: GPG error: http://packages.cloud.google.com ruby-runtime-jessie InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6A030B21BA07F4FB
```

I fixed it. Please check it.