### PR TITLE
Switch back to docker until Kaniko PR 546 is released

### DIFF
--- a/ruby-pipeline/ruby-latest.yaml
+++ b/ruby-pipeline/ruby-latest.yaml
@@ -45,5 +45,7 @@ steps:
            '--prebuilt-image=2.6.0=gcr.io/gcp-runtimes/ruby/ubuntu16/prebuilt/ruby-2.6.0:latest',
            '--prebuilt-image=2.6.1=gcr.io/gcp-runtimes/ruby/ubuntu16/prebuilt/ruby-2.6.1:latest',
            '--default-ruby-version=2.3.8']
-  - name: 'gcr.io/kaniko-project/executor:v0.8.0'
-    args: ['--destination=$_OUTPUT_IMAGE']
+  - name: 'gcr.io/cloud-builders/docker:latest'
+    args: ['build', '--network=cloudbuild', '-t', '$_OUTPUT_IMAGE', '.']
+images:
+  - '$_OUTPUT_IMAGE'


### PR DESCRIPTION
A Kaniko 0.8 bug is affecting the runtime (see https://github.com/GoogleCloudPlatform/ruby-docker/issues/165). Switch back to Docker until https://github.com/GoogleContainerTools/kaniko/pull/546 is included in a Kaniko release.

/cc @dlorenc 