### PR TITLE
feat: add `--entrypoint` to support buildpack-based images

### DIFF
--- a/app-engine-exec-wrapper/README.md
+++ b/app-engine-exec-wrapper/README.md
@@ -3,12 +3,12 @@
 This is a wrapper Docker image that sets up an environment similar to the
 [Google App Engine Flexible Environment](https://cloud.google.com/appengine/docs/flexible/),
 suitable for running scripts and maintenance tasks provided by an application
-deployed to App Engine. In particular, it ensures a suitable CloudSQL Proxy
+deployed to App Engine. In particular, it ensures a suitable Cloud SQL Proxy
 is running in the environment.
 
 Its driving use case is running production database migrations for Ruby on
-Rails applications, and we expect similar uses for other languasges and
-frameworks.
+Rails applications, but it is also useful for Django applications, and we
+expect similar uses for other languages and frameworks.
 
 ## Usage
 
@@ -30,6 +30,43 @@ You can find the image path using `gcloud app versions describe`.
 
 Ruby developers may use the [appengine gem](https://rubygems.org/gems/appengine)
 for a convenient Rake-based interface.
+
+## Usage for Cloud Run
+
+This wrapper can also be used for applications deployed to Cloud Run by defining
+your image name in the arguments. It would typically be added after your image build and image push steps"
+
+    steps:
+    ...
+    - name: "gcr.io/google-appengine/exec-wrapper"
+      args: ["-i", "gcr.io/my-project/my-image",
+             ...]
+
+
+If the Cloud Run image is built with [Google Cloud Buildpacks](https://github.com/GoogleCloudPlatform/buildpacks),
+you must define an entrypoint. By default you can use the `launcher` entrypoint: 
+
+
+    steps:
+    ...
+    - name: "gcr.io/google-appengine/exec-wrapper"
+      args: [...
+             "-r", "launcher", 
+             "--", "bundle", "exec", "rake", "db:migrate"]
+
+Alternatively, you can define your migration command as an entrypoint in `Procfile`,
+and use that instead of a direct command: 
+
+    # Procfile
+    web: bundle exec rails server
+    migrate: bundle exec rake db:migrate
+
+    # cloudbuild.yaml
+    steps:
+    ...
+    - name: "gcr.io/google-appengine/exec-wrapper"
+      args: [...
+             "-r", "migrate"]
 
 ## Building and testing
 

--- a/app-engine-exec-wrapper/execute.sh
+++ b/app-engine-exec-wrapper/execute.sh
@@ -26,7 +26,7 @@ PRE_PULL=true
 CONTAINER_NETWORK=cloudbuild
 
 OPTIND=1
-while getopts ":e:i:n:s:t:xP" opt; do
+while getopts ":e:i:n:s:t:xP:r" opt; do
   case $opt in
     e)
       ENV_PARAMS+=(-e "$OPTARG")
@@ -48,6 +48,9 @@ while getopts ":e:i:n:s:t:xP" opt; do
       ;;
     P)
       PRE_PULL=
+      ;;
+    r)
+      ENTRYPOINT=
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -97,10 +100,14 @@ if [ -n "${SQL_INSTANCES}" ]; then
   fi
 fi
 
+if [ -n "${ENTRYPOINT}" ]; then
+  ENTRYPOINT="--entrypoint ${ENTRYPOINT}"
+fi
+
 echo
 echo "---------- EXECUTE COMMAND ----------"
 echo "$@"
-docker run --rm --volumes-from=${CONTAINER} --network=${CONTAINER_NETWORK} "${ENV_PARAMS[@]}" ${IMAGE} "$@"
+docker run --rm "${ENTRYPOINT}" --volumes-from=${CONTAINER} --network=${CONTAINER_NETWORK} "${ENV_PARAMS[@]}" ${IMAGE} "$@"
 
 echo
 echo "---------- CLEANUP ----------"

--- a/app-engine-exec-wrapper/execute.sh
+++ b/app-engine-exec-wrapper/execute.sh
@@ -101,7 +101,7 @@ if [ -n "${SQL_INSTANCES}" ]; then
 fi
 
 if [ -n "${ENTRYPOINT}" ]; then
-  ENTRYPOINT="--entrypoint ${ENTRYPOINT}"
+  ENTRYPOINT="--entrypoint \"${ENTRYPOINT}\""
 fi
 
 echo

--- a/app-engine-exec-wrapper/execute.sh
+++ b/app-engine-exec-wrapper/execute.sh
@@ -26,7 +26,7 @@ PRE_PULL=true
 CONTAINER_NETWORK=cloudbuild
 
 OPTIND=1
-while getopts ":e:i:n:s:t:xP:r" opt; do
+while getopts ":e:i:n:s:t:xPr:" opt; do
   case $opt in
     e)
       ENV_PARAMS+=(-e "$OPTARG")
@@ -50,7 +50,7 @@ while getopts ":e:i:n:s:t:xP:r" opt; do
       PRE_PULL=
       ;;
     r)
-      ENTRYPOINT=
+      ENTRYPOINT=$OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -107,7 +107,8 @@ fi
 echo
 echo "---------- EXECUTE COMMAND ----------"
 echo "$@"
-docker run --rm "${ENTRYPOINT}" --volumes-from=${CONTAINER} --network=${CONTAINER_NETWORK} "${ENV_PARAMS[@]}" ${IMAGE} "$@"
+
+docker run --rm ${ENTRYPOINT} --volumes-from=${CONTAINER} --network=${CONTAINER_NETWORK} "${ENV_PARAMS[@]}" ${IMAGE} "$@"
 
 echo
 echo "---------- CLEANUP ----------"


### PR DESCRIPTION
exec-wrapper can be used for data migrations for Cloud Run applications, as seen in the [Django on Cloud Run tutorial](https://cloud.google.com/python/django/run).

However, for Cloud Run applications whose images are built with [Cloud Buildpacks](https://github.com/GoogleCloudPlatform/buildpack), the Docker command in `execute.sh` needs to specify an entrypoint so that a custom command can be run (as Buildpacks define the entrypoint as the web process defined in `Procfile`, and this needs to be overridden)

This PR adds this functionality, as well as some additions to the exec-wrapper readme to show it's usage. 