### PR TITLE
Fixed entrypoint handling for images built with Google Cloud Buildpacks

### DIFF
--- a/app-engine-exec-wrapper/execute.sh
+++ b/app-engine-exec-wrapper/execute.sh
@@ -104,7 +104,7 @@ if [ -n "${SQL_INSTANCES}" ]; then
 fi
 
 if [ -n "${ENTRYPOINT}" ]; then
-  ENTRYPOINT="--entrypoint \"${ENTRYPOINT}\""
+  ENTRYPOINT="--entrypoint ${ENTRYPOINT}"
 fi
 
 echo


### PR DESCRIPTION
After running multiple tests I couldn't make entrypoint to work with images generated using buildpacks while quoted. After removing this quote everything works correctly. 

Quoted version will always throw error like:
```
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "\"launcher\"": executable file not found in $PATH: unknown.
```