### PR TITLE
fix(ruby-docker): add pip install trusted hosts to fix SSLCertVerificationError

### DIFF
--- a/runtime-config.env
+++ b/runtime-config.env
@@ -49,4 +49,4 @@ GCLOUD_VERSION=387.0.0
 # This is the version of the libssl1.0 package in Ubuntu 20_04, used to build
 # pre-2.4 versions of Ruby. It should match what is available under the
 # directory http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/
-SSL10_VERSION=1.0.2n-1ubuntu5.10
+SSL10_VERSION=1.0.2n-1ubuntu5.13

--- a/tools/ci-scripts/deploy_check.sh
+++ b/tools/ci-scripts/deploy_check.sh
@@ -12,11 +12,11 @@ fi
 
 cd ${KOKORO_GFILE_DIR}/appengine/integration_tests
 
-sudo /usr/local/bin/pip install --upgrade -r requirements.txt
+sudo /usr/local/bin/pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade -r requirements.txt
 
 if [ -f ${KOKORO_GITHUB_DIR}/${SAMPLE_APP_DIRECTORY}/requirements.txt ]
 then
-  sudo /usr/local/bin/pip install --upgrade -r ${KOKORO_GITHUB_DIR}/${SAMPLE_APP_DIRECTORY}/requirements.txt
+  sudo /usr/local/bin/pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade -r ${KOKORO_GITHUB_DIR}/${SAMPLE_APP_DIRECTORY}/requirements.txt
 fi
 
 export DEPLOY_LATENCY_PROJECT='cloud-deploy-latency'

--- a/tools/ci-scripts/integration-test.sh
+++ b/tools/ci-scripts/integration-test.sh
@@ -7,11 +7,11 @@ source ${KOKORO_GFILE_DIR}/kokoro/common.sh
 
 export GOOGLE_CLOUD_PROJECT=gcp-runtimes
 
-sudo /usr/local/bin/pip install --upgrade -r ${KOKORO_GFILE_DIR}/appengine/integration_tests/requirements.txt
+sudo /usr/local/bin/pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade -r ${KOKORO_GFILE_DIR}/appengine/integration_tests/requirements.txt
 
 if [ -f ${KOKORO_GITHUB_DIR}/${SAMPLE_APP_DIRECTORY}/requirements.txt ]
 then
-  sudo /usr/local/bin/pip install --upgrade -r ${KOKORO_GITHUB_DIR}/${SAMPLE_APP_DIRECTORY}/requirements.txt
+  sudo /usr/local/bin/pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade -r ${KOKORO_GITHUB_DIR}/${SAMPLE_APP_DIRECTORY}/requirements.txt
 fi
 
 export GOPATH=${KOKORO_GITHUB_DIR}/${SAMPLE_APP_DIRECTORY}


### PR DESCRIPTION
Kokoro Builds:
- deploy_check
- integration-test
- integration-test-builder