### PR TITLE
Updating the app-engine-exec-wrapper shell script to stop replacing the "/workspace" when including volumes from the container

### DIFF
--- a/app-engine-exec-wrapper/execute.sh
+++ b/app-engine-exec-wrapper/execute.sh
@@ -81,6 +81,17 @@ if [ -z "$CONTAINER" ]; then
   exit 1
 fi
 
+VOLUMES=$(docker inspect "$CONTAINER" |
+  awk '
+    /"Source":/      { gsub(/"|,/, "", $2); source=$2 }
+    /"Destination":/ {
+      gsub(/"|,/, "", $2);
+      dest=$2;
+      if (dest != "/workspace")
+        printf("-v %s:%s ", source, dest);
+    }
+  ')
+
 if [ -n "$PRE_PULL" ]; then
   echo
   echo "---------- INSTALL IMAGE ----------"
@@ -111,7 +122,7 @@ echo
 echo "---------- EXECUTE COMMAND ----------"
 echo "$@"
 
-docker run --rm ${ENTRYPOINT} --volumes-from=${CONTAINER} --network=${CONTAINER_NETWORK} "${ENV_PARAMS[@]}" ${IMAGE} "$@"
+docker run --rm ${ENTRYPOINT} ${VOLUMES} --network=${CONTAINER_NETWORK} "${ENV_PARAMS[@]}" ${IMAGE} "$@"
 
 echo
 echo "---------- CLEANUP ----------"


### PR DESCRIPTION
When the application image comes from a custom build pack, loading all volumes from the container results in "/workspace" being overwritten. This results in the application files no longer being available, which can cause commands to fail (like running rake tasks in CloudBuild or via the `appengine:exec` rake task through the `appengine` gem).

I modified the app engine exec wrapper's execute shell script to replace the `--volumes-from` flag with a series of `-v` flags, allowing us to filter out any volumes from the container that would overwrite the "/workspace" path.  This allows other volumes that contain useful helpers to continue to mount on the image, while also not losing the application files.

I made these changes, based on PR #229 seemingly having stalled out, in hopes the reason for it not being merged in was because there were other volumes that needed to continue to be included other than the "/cloudsql" one, such as "/builder/home", "/builder/outputs", and "/cloudbuild/scripts".  This specifically targets "/workspace" to prevent the application files from being overwritten by the script.